### PR TITLE
[codex] Add local smoke test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.tmp/
 .env
 .DS_Store
 coverage/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,30 @@ pnpm validate-config -- --config config/pools.yaml --env .env
 pnpm render-compose -- --config config/pools.yaml --env .env --output docker-compose.generated.yml
 pnpm check-runner-version -- --env .env
 pnpm runner-release-manifest -- --env .env
+pnpm smoke-test
+```
+
+## Local Smoke Test
+
+Run this from a machine with a live Docker daemon and Buildx support:
+
+```bash
+pnpm smoke-test
+```
+
+The smoke test:
+
+- builds the local runner image
+- starts a mock GitHub token API on an isolated Docker network
+- mounts stubbed `config.sh` and `run.sh` files into `/actions-runner`
+- verifies registration token fetch, runner config flags, run invocation, remove token fetch, and cleanup
+
+Useful overrides:
+
+```bash
+DOCKER_CONTEXT=colima pnpm smoke-test
+SMOKE_PLATFORM=linux/amd64 pnpm smoke-test
+SMOKE_KEEP_ARTIFACTS=1 pnpm smoke-test
 ```
 
 ## Manual Acceptance Checklist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,4 +42,7 @@ COPY docker/runner-entrypoint.sh /usr/local/bin/runner-entrypoint.sh
 
 RUN chmod 0755 /usr/local/bin/runner-entrypoint.sh
 
+HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
+  CMD pgrep -f "Runner.Listener" > /dev/null || exit 1
+
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/runner-entrypoint.sh"]

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -90,7 +90,7 @@ cleanup_runner() {
     return 0
   fi
 
-  if ! gosu runner bash -lc "cd '${RUNNER_HOME}' && ./config.sh remove --token '${remove_token}'"; then
+  if ! RUNNER_TOKEN="${remove_token}" gosu runner bash -lc 'cd "${RUNNER_HOME}" && ./config.sh remove --token "${RUNNER_TOKEN}"'; then
     log "runner removal command failed; check GitHub runner inventory for stale registrations"
     return 0
   fi

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "tsc --noEmit -p tsconfig.json",
     "render-compose": "tsx src/cli.ts render-compose",
     "runner-release-manifest": "tsx src/cli.ts runner-release-manifest",
+    "smoke-test": "bash scripts/smoke-test.sh",
     "test": "vitest run",
     "validate-config": "tsx src/cli.ts validate-config"
   },

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -47,5 +47,5 @@ docker buildx build \
   --build-arg "RUNNER_VERSION=${RUNNER_VERSION}" \
   -f docker/Dockerfile \
   -t "${IMAGE_REF}" \
-  ${PUSH_FLAG} \
+  ${PUSH_FLAG:+"${PUSH_FLAG}"} \
   .

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKER_CONTEXT="${DOCKER_CONTEXT:-$(docker context show 2>/dev/null || true)}"
+IMAGE_REF="${SMOKE_IMAGE_REF:-synology-github-runner:smoke}"
+KEEP_ARTIFACTS="${SMOKE_KEEP_ARTIFACTS:-0}"
+TEMP_PARENT="${ROOT_DIR}/.tmp"
+NETWORK="sgr-smoke-${RANDOM}${RANDOM}"
+API_CONTAINER="sgr-smoke-api-${RANDOM}${RANDOM}"
+RUNNER_CONTAINER="sgr-smoke-runner-${RANDOM}${RANDOM}"
+
+mkdir -p "${TEMP_PARENT}"
+TEMP_DIR="$(mktemp -d "${TEMP_PARENT}/smoke-test.XXXXXX")"
+STATE_DIR="${TEMP_DIR}/state"
+LOG_DIR="${TEMP_DIR}/logs"
+ACTIONS_RUNNER_DIR="${TEMP_DIR}/actions-runner"
+RUNNER_STDOUT="${TEMP_DIR}/runner.stdout.log"
+
+docker_cmd() {
+  if [[ -n "${DOCKER_CONTEXT}" ]]; then
+    docker --context "${DOCKER_CONTEXT}" "$@"
+  else
+    docker "$@"
+  fi
+}
+
+log() {
+  printf '[smoke-test] %s\n' "$*"
+}
+
+cleanup() {
+  local exit_code=$?
+
+  docker_cmd rm -f "${RUNNER_CONTAINER}" >/dev/null 2>&1 || true
+  docker_cmd rm -f "${API_CONTAINER}" >/dev/null 2>&1 || true
+  docker_cmd network rm "${NETWORK}" >/dev/null 2>&1 || true
+
+  if [[ "${KEEP_ARTIFACTS}" == "1" ]]; then
+    log "kept smoke artifacts at ${TEMP_DIR}"
+  else
+    rm -rf "${TEMP_DIR}"
+  fi
+
+  exit "${exit_code}"
+}
+
+trap cleanup EXIT
+
+default_platform() {
+  local machine
+  machine="$(uname -m)"
+  case "${machine}" in
+    arm64|aarch64)
+      printf 'linux/arm64'
+      ;;
+    x86_64|amd64)
+      printf 'linux/amd64'
+      ;;
+    *)
+      printf 'linux/arm64'
+      ;;
+  esac
+}
+
+SMOKE_PLATFORM="${SMOKE_PLATFORM:-$(default_platform)}"
+
+mkdir -p "${STATE_DIR}" "${LOG_DIR}" "${ACTIONS_RUNNER_DIR}"
+cp "${ROOT_DIR}/scripts/smoke/actions-runner/config.sh" "${ACTIONS_RUNNER_DIR}/config.sh"
+cp "${ROOT_DIR}/scripts/smoke/actions-runner/run.sh" "${ACTIONS_RUNNER_DIR}/run.sh"
+chmod +x "${ACTIONS_RUNNER_DIR}/config.sh" "${ACTIONS_RUNNER_DIR}/run.sh"
+
+log "building ${IMAGE_REF} for ${SMOKE_PLATFORM}"
+DOCKER_CONTEXT="${DOCKER_CONTEXT}" "${ROOT_DIR}/scripts/build-image.sh" "${IMAGE_REF}" --platform "${SMOKE_PLATFORM}"
+
+log "creating smoke network ${NETWORK}"
+docker_cmd network create "${NETWORK}" >/dev/null
+
+log "starting mock token API"
+docker_cmd run -d --rm \
+  --name "${API_CONTAINER}" \
+  --network "${NETWORK}" \
+  --network-alias mock-api \
+  -e MOCK_LOG_PATH=/logs/mock-api.log \
+  -v "${ROOT_DIR}/scripts/smoke/mock-api.mjs:/app/mock-api.mjs:ro" \
+  -v "${LOG_DIR}:/logs" \
+  node:24-alpine \
+  node /app/mock-api.mjs >/dev/null
+
+for _ in $(seq 1 20); do
+  if [[ -f "${LOG_DIR}/mock-api.log" ]] && grep -q "listening 0.0.0.0:8080" "${LOG_DIR}/mock-api.log"; then
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ ! -f "${LOG_DIR}/mock-api.log" ]] || ! grep -q "listening 0.0.0.0:8080" "${LOG_DIR}/mock-api.log"; then
+  log "mock token API did not become ready"
+  exit 1
+fi
+
+log "running runner image smoke flow"
+docker_cmd run --rm \
+  --name "${RUNNER_CONTAINER}" \
+  --network "${NETWORK}" \
+  -e GITHUB_PAT=fake-pat \
+  -e GITHUB_API_URL=http://mock-api:8080 \
+  -e GITHUB_ORG=test-org \
+  -e RUNNER_NAME=smoke-runner-01 \
+  -e RUNNER_GROUP=synology-private \
+  -e RUNNER_LABELS=synology,shell-only,private \
+  -e RUNNER_ALLOWED_REPOSITORIES=test-org/private-app \
+  -e RUNNER_STATE_DIR=/tmp/runner-state \
+  -e RUNNER_LOG_DIR=/tmp/runner-state/logs \
+  -e RUNNER_WORK_DIR=/tmp/runner-state/_work \
+  -v "${STATE_DIR}:/tmp/runner-state" \
+  -v "${ACTIONS_RUNNER_DIR}:/actions-runner" \
+  "${IMAGE_REF}" | tee "${RUNNER_STDOUT}"
+
+grep -q "POST /orgs/test-org/actions/runners/registration-token" "${LOG_DIR}/mock-api.log"
+grep -q "POST /orgs/test-org/actions/runners/remove-token" "${LOG_DIR}/mock-api.log"
+grep -q -- "--runnergroup synology-private --ephemeral --disableupdate" "${STATE_DIR}/config-invocations.log"
+grep -q "^job output$" "${STATE_DIR}/logs/runner.log"
+grep -q "run.sh stub executed" "${STATE_DIR}/run.log"
+grep -q "runner registration removed cleanly" "${RUNNER_STDOUT}"
+
+log "smoke test passed"
+log "image=${IMAGE_REF}"
+log "context=${DOCKER_CONTEXT:-default}"

--- a/scripts/smoke/actions-runner/config.sh
+++ b/scripts/smoke/actions-runner/config.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${RUNNER_STATE_DIR}/config-invocations.log"
+mkdir -p "$(dirname "${log_file}")"
+printf '%s %s\n' "$(date -Iseconds)" "$*" >> "${log_file}"
+
+if [[ "${1:-}" == "remove" ]]; then
+  exit 0
+fi
+
+touch .runner .credentials .credentials_rsaparams

--- a/scripts/smoke/actions-runner/run.sh
+++ b/scripts/smoke/actions-runner/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s run.sh stub executed\n' "$(date -Iseconds)" >> "${RUNNER_STATE_DIR}/run.log"
+mkdir -p "${RUNNER_WORK_DIR}/workspace"
+touch "${RUNNER_WORK_DIR}/workspace/job.txt"
+echo "job output"

--- a/scripts/smoke/mock-api.mjs
+++ b/scripts/smoke/mock-api.mjs
@@ -1,0 +1,37 @@
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+
+const logPath = process.env.MOCK_LOG_PATH ?? "/tmp/mock-api.log";
+fs.mkdirSync(path.dirname(logPath), { recursive: true });
+
+const server = http.createServer((req, res) => {
+  fs.appendFileSync(
+    logPath,
+    `${new Date().toISOString()} ${req.method} ${req.url}\n`,
+    "utf8"
+  );
+
+  if (req.method === "POST" && req.url === "/orgs/test-org/actions/runners/registration-token") {
+    res.writeHead(201, { "content-type": "application/json" });
+    res.end(JSON.stringify({ token: "registration-token" }));
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/orgs/test-org/actions/runners/remove-token") {
+    res.writeHead(201, { "content-type": "application/json" });
+    res.end(JSON.stringify({ token: "remove-token" }));
+    return;
+  }
+
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "not found" }));
+});
+
+server.listen(8080, "0.0.0.0", () => {
+  fs.appendFileSync(
+    logPath,
+    `${new Date().toISOString()} listening 0.0.0.0:8080\n`,
+    "utf8"
+  );
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,8 +36,8 @@ async function validateConfig(args: string[]): Promise<void> {
     envPath: getOption(args, "--env", ".env"),
     requirePat: false
   });
-  const configPath = getOption(args, "--config", "config/pools.yaml") ?? "config/pools.yaml";
-  const config = loadConfig(configPath, env);
+  const configPath = getOption(args, "--config", "config/pools.yaml");
+  const config = loadConfig(configPath!, env);
 
   process.stdout.write(
     JSON.stringify(
@@ -66,8 +66,8 @@ async function renderComposeCommand(args: string[]): Promise<void> {
     envPath: getOption(args, "--env", ".env"),
     requirePat: false
   });
-  const configPath = getOption(args, "--config", "config/pools.yaml") ?? "config/pools.yaml";
-  const config = loadConfig(configPath, env);
+  const configPath = getOption(args, "--config", "config/pools.yaml");
+  const config = loadConfig(configPath!, env);
   const compose = renderCompose(config, env);
 
   if (output) {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import dotenv from "dotenv";
+import { normalizeRunnerVersion } from "./runner-version.js";
 
 export interface DeploymentEnv {
   githubPat?: string;
@@ -59,8 +60,4 @@ export function loadDeploymentEnv(
 
 function normalizeUrl(value: string): string {
   return value.replace(/\/+$/, "");
-}
-
-function normalizeRunnerVersion(value: string): string {
-  return value.replace(/^v/i, "");
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -43,10 +43,6 @@ export function buildGitHubApiHeaders(
   return headers;
 }
 
-export function buildOrganizationRunnerUrl(organization: string): string {
-  return `https://github.com/${organization}`;
-}
-
 export function buildRegistrationTokenRequest(
   apiUrl: string,
   organization: string,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -82,6 +82,46 @@ pools:
       /outside organization example/
     );
   });
+
+  test("rejects duplicate pool keys", () => {
+    const directory = createTempDir();
+    const configPath = path.join(directory, "pools.yaml");
+
+    fs.writeFileSync(
+      configPath,
+      `version: 1
+image:
+  repository: ghcr.io/example/synology-github-runner
+  tag: 0.1.0
+pools:
+  - key: synology-private
+    visibility: private
+    organization: example
+    runnerGroup: synology-private
+    allowedRepositories:
+      - example/private-app
+    labels: []
+    size: 1
+    architecture: arm64
+    runnerRoot: /volume1/docker/synology-github-runner/pools/synology-private
+  - key: synology-private
+    visibility: private
+    organization: example
+    runnerGroup: synology-private
+    allowedRepositories:
+      - example/other-app
+    labels: []
+    size: 1
+    architecture: arm64
+    runnerRoot: /volume1/docker/synology-github-runner/pools/synology-private-2
+`,
+      "utf8"
+    );
+
+    expect(() => loadConfig(configPath, deploymentEnv())).toThrow(
+      /duplicate pool key/
+    );
+  });
 });
 
 function deploymentEnv(): DeploymentEnv {

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { loadDeploymentEnv } from "../src/lib/env.js";
+
+const tempPaths: string[] = [];
+
+afterEach(() => {
+  for (const tempPath of tempPaths.splice(0)) {
+    fs.rmSync(tempPath, { recursive: true, force: true });
+  }
+});
+
+describe("loadDeploymentEnv", () => {
+  test("loads defaults when no .env file exists", () => {
+    const env = loadDeploymentEnv({
+      envPath: "/nonexistent/.env",
+      requirePat: false
+    });
+
+    expect(env.githubApiUrl).toBe("https://api.github.com");
+    expect(env.composeProjectName).toBe("synology-github-runner");
+    expect(env.runnerVersion).toBe("2.333.0");
+    expect(env.githubPat).toBeUndefined();
+  });
+
+  test("throws when GITHUB_PAT is required but missing", () => {
+    expect(() =>
+      loadDeploymentEnv({
+        envPath: "/nonexistent/.env",
+        requirePat: true
+      })
+    ).toThrow(/GITHUB_PAT is required/);
+  });
+
+  test("reads values from .env file", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "synology-env-"));
+    tempPaths.push(directory);
+    const envPath = path.join(directory, ".env");
+
+    fs.writeFileSync(
+      envPath,
+      "GITHUB_PAT=test-token\nRUNNER_VERSION=v2.340.0\n",
+      "utf8"
+    );
+
+    const env = loadDeploymentEnv({ envPath, requirePat: true });
+    expect(env.githubPat).toBe("test-token");
+    expect(env.runnerVersion).toBe("2.340.0");
+  });
+
+  test("strips trailing slashes from API URL", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "synology-env-"));
+    tempPaths.push(directory);
+    const envPath = path.join(directory, ".env");
+
+    fs.writeFileSync(envPath, "GITHUB_API_URL=https://ghe.example.com/api/v3///\n", "utf8");
+
+    const env = loadDeploymentEnv({ envPath, requirePat: false });
+    expect(env.githubApiUrl).toBe("https://ghe.example.com/api/v3");
+  });
+});

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -65,4 +65,46 @@ describe("github runner API helpers", () => {
         publishedAt: "2026-03-25T00:00:00Z"
       });
   });
+
+  test("throws on non-ok token response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Bad credentials"
+    });
+
+    await expect(
+      fetchRunnerToken(
+        buildRegistrationTokenRequest("https://api.github.com", "example", "bad"),
+        fetchMock
+      )
+    ).rejects.toThrow(/failed with 401/);
+  });
+
+  test("throws when token field is missing from response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({})
+    });
+
+    await expect(
+      fetchRunnerToken(
+        buildRegistrationTokenRequest("https://api.github.com", "example", "secret"),
+        fetchMock
+      )
+    ).rejects.toThrow(/did not include a token/);
+  });
+
+  test("throws on non-ok release response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => "Not Found"
+    });
+
+    await expect(
+      fetchLatestRunnerRelease("https://api.github.com", "secret", fetchMock)
+    ).rejects.toThrow(/failed with 404/);
+  });
 });


### PR DESCRIPTION
## Summary

- add a repo-native `pnpm smoke-test` command for the runner image
- add a Docker-networked mock GitHub token API and stubbed runner scripts to exercise the entrypoint flow end to end
- document local smoke-test usage and supported overrides in the README

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `DOCKER_CONTEXT=colima pnpm smoke-test`
