### PR TITLE
Bump runner image to 0.1.5 and harden self-hosted runner toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,27 @@ jobs:
       - uses: pnpm/action-setup@v5
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: pnpm
+      - name: Install Node.js
+        run: |
+          case "$(uname -m)" in
+            x86_64) node_arch="x64" ;;
+            aarch64|arm64) node_arch="arm64" ;;
+            *)
+              echo "Unsupported runner architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+
+          node_version="24.14.1"
+          archive="node-v${node_version}-linux-${node_arch}.tar.xz"
+          install_dir="${RUNNER_TEMP}/node-${node_version}-${node_arch}"
+
+          curl -fsSL "https://nodejs.org/dist/v${node_version}/${archive}" -o "${RUNNER_TEMP}/${archive}"
+          rm -rf "${install_dir}"
+          mkdir -p "${install_dir}"
+          tar -xJf "${RUNNER_TEMP}/${archive}" --strip-components=1 --no-same-owner -C "${install_dir}"
+          echo "${install_dir}/bin" >> "$GITHUB_PATH"
+          "${install_dir}/bin/node" --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_private:
+  test_self_hosted_trusted:
     name: test
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on:
       - self-hosted
       - synology
       - shell-only
-      - private
+      - public
     env:
       RUNNER_TEMP: /tmp/github-runner-temp
       RUNNER_TOOL_CACHE: /tmp/github-runner-tool-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,27 @@ jobs:
       - uses: pnpm/action-setup@v5
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
+      - name: Install Node.js
+        run: |
+          case "$(uname -m)" in
+            x86_64) node_arch="x64" ;;
+            aarch64|arm64) node_arch="arm64" ;;
+            *)
+              echo "Unsupported runner architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+
+          node_version="24.14.1"
+          archive="node-v${node_version}-linux-${node_arch}.tar.xz"
+          install_dir="${RUNNER_TEMP}/node-${node_version}-${node_arch}"
+
+          curl -fsSL "https://nodejs.org/dist/v${node_version}/${archive}" -o "${RUNNER_TEMP}/${archive}"
+          rm -rf "${install_dir}"
+          mkdir -p "${install_dir}"
+          tar -xJf "${RUNNER_TEMP}/${archive}" --strip-components=1 --no-same-owner -C "${install_dir}"
+          echo "${install_dir}/bin" >> "$GITHUB_PATH"
+          "${install_dir}/bin/node" --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,66 @@ jobs:
       - run: pnpm test
       - run: pnpm build
 
+  shell_safe_contract_trusted:
+    name: shell-safe contract
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - synology
+      - shell-only
+      - public
+    env:
+      RUNNER_TEMP: /tmp/github-runner-temp
+      RUNNER_TOOL_CACHE: /opt/hostedtoolcache
+      AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
+      TF_PLUGIN_CACHE_DIR: /tmp/github-runner-temp/terraform-plugin-cache
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare shell-safe cache directories
+        run: |
+          mkdir -p \
+            "$RUNNER_TEMP" \
+            "$RUNNER_TOOL_CACHE" \
+            "$TF_PLUGIN_CACHE_DIR" \
+            .tmp/ci-shell-safe/npm \
+            .tmp/ci-shell-safe/pip \
+            .tmp/ci-shell-safe/terraform
+      - uses: actions/cache@v4
+        with:
+          path: |
+            .tmp/ci-shell-safe/npm
+            .tmp/ci-shell-safe/pip
+            ${{ env.TF_PLUGIN_CACHE_DIR }}
+          key: ${{ runner.os }}-shell-safe-contract-${{ hashFiles('docker/Dockerfile', '.github/workflows/ci.yml') }}
+      - name: Verify built-in shell-safe toolchain
+        run: |
+          bash --version | head -n 1
+          git --version
+          tar --version | head -n 1
+          zstd --version | head -n 1
+          node --version
+          npm --version
+          python3.12 --version
+          python --version
+          terraform version
+      - name: Verify cache-aware commands
+        env:
+          npm_config_cache: ${{ github.workspace }}/.tmp/ci-shell-safe/npm
+          PIP_CACHE_DIR: ${{ github.workspace }}/.tmp/ci-shell-safe/pip
+        run: |
+          python3.12 -m venv .venv-contract
+          source .venv-contract/bin/activate
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip cache dir
+          npm config get cache
+          cat > .tmp/ci-shell-safe/terraform/main.tf <<'EOF'
+          terraform {
+            required_version = "= 1.6.6"
+          }
+          EOF
+          terraform -chdir=.tmp/ci-shell-safe/terraform init -backend=false
+
   test_public_fork_pr:
     name: test
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,27 +36,9 @@ jobs:
       - uses: pnpm/action-setup@v5
         with:
           version: 10.32.1
-      - name: Install Node.js
-        run: |
-          case "$(uname -m)" in
-            x86_64) node_arch="x64" ;;
-            aarch64|arm64) node_arch="arm64" ;;
-            *)
-              echo "Unsupported runner architecture: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-
-          node_version="24.14.1"
-          archive="node-v${node_version}-linux-${node_arch}.tar.xz"
-          install_dir="${RUNNER_TEMP}/node-${node_version}-${node_arch}"
-
-          curl -fsSL "https://nodejs.org/dist/v${node_version}/${archive}" -o "${RUNNER_TEMP}/${archive}"
-          rm -rf "${install_dir}"
-          mkdir -p "${install_dir}"
-          tar -xJf "${RUNNER_TEMP}/${archive}" --strip-components=1 --no-same-owner -C "${install_dir}"
-          echo "${install_dir}/bin" >> "$GITHUB_PATH"
-          "${install_dir}/bin/node" --version
+      - uses: ./actions/setup-shell-safe-node
+        with:
+          node-version: 24.14.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test_private:
+    name: test
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - synology
+      - shell-only
+      - private
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10.32.1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm build
+
+  test_public_fork_pr:
+    name: test
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
       - public
     env:
       RUNNER_TEMP: /tmp/github-runner-temp
-      RUNNER_TOOL_CACHE: /tmp/github-runner-tool-cache
+      RUNNER_TOOL_CACHE: /opt/hostedtoolcache
+      AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -35,27 +36,10 @@ jobs:
       - uses: pnpm/action-setup@v5
         with:
           version: 10.32.1
-      - name: Install Node.js
-        run: |
-          case "$(uname -m)" in
-            x86_64) node_arch="x64" ;;
-            aarch64|arm64) node_arch="arm64" ;;
-            *)
-              echo "Unsupported runner architecture: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-
-          node_version="24.14.1"
-          archive="node-v${node_version}-linux-${node_arch}.tar.xz"
-          install_dir="${RUNNER_TEMP}/node-${node_version}-${node_arch}"
-
-          curl -fsSL "https://nodejs.org/dist/v${node_version}/${archive}" -o "${RUNNER_TEMP}/${archive}"
-          rm -rf "${install_dir}"
-          mkdir -p "${install_dir}"
-          tar -xJf "${RUNNER_TEMP}/${archive}" --strip-components=1 --no-same-owner -C "${install_dir}"
-          echo "${install_dir}/bin" >> "$GITHUB_PATH"
-          "${install_dir}/bin/node" --version
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
@@ -73,7 +57,7 @@ jobs:
           version: 10.32.1
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: "24"
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,13 @@ jobs:
       - synology
       - shell-only
       - private
+    env:
+      RUNNER_TEMP: /tmp/github-runner-temp
+      RUNNER_TOOL_CACHE: /tmp/github-runner-tool-cache
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+      - run: mkdir -p "$RUNNER_TEMP" "$RUNNER_TOOL_CACHE"
       - uses: pnpm/action-setup@v5
         with:
           version: 10.32.1

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -2,9 +2,15 @@ name: Release Image
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_project_release:
+        description: Create the matching Git tag and GitHub Release after image verification
+        required: false
+        default: false
+        type: boolean
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 concurrency:
@@ -48,15 +54,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: image
+      - id: release_meta
         run: |
           node --input-type=module <<'EOF'
           import fs from "node:fs";
           import YAML from "yaml";
 
           const config = YAML.parse(fs.readFileSync("config/pools.yaml", "utf8"));
+          const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
           if (!config?.image?.repository || !config?.image?.tag) {
             throw new Error("config/pools.yaml must define image.repository and image.tag");
+          }
+          if (!packageJson?.version) {
+            throw new Error("package.json must define version");
+          }
+          if (packageJson.version !== config.image.tag) {
+            throw new Error(
+              `package.json version ${packageJson.version} must match config image tag ${config.image.tag}`
+            );
           }
 
           fs.appendFileSync(
@@ -67,12 +82,23 @@ jobs:
             process.env.GITHUB_OUTPUT,
             `image_tag=${config.image.tag}\n`
           );
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `release_tag=v${packageJson.version}\n`
+          );
           EOF
 
-      - run: ./scripts/build-image.sh "${{ steps.image.outputs.image_ref }}" --push
+      - if: ${{ inputs.publish_project_release }}
+        run: |
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "publish_project_release may only run from main" >&2
+            exit 1
+          fi
+
+      - run: ./scripts/build-image.sh "${{ steps.release_meta.outputs.image_ref }}" --push
 
       - run: |
-          docker buildx imagetools inspect "${{ steps.image.outputs.image_ref }}" | tee /tmp/imagetools.txt
+          docker buildx imagetools inspect "${{ steps.release_meta.outputs.image_ref }}" | tee /tmp/imagetools.txt
           grep -q "linux/amd64" /tmp/imagetools.txt
           grep -q "linux/arm64" /tmp/imagetools.txt
 
@@ -90,9 +116,23 @@ jobs:
           done
 
       - run: |
-          docker run --rm --platform linux/amd64 --entrypoint /bin/sh "${{ steps.image.outputs.image_ref }}" -lc \
+          docker run --rm --platform linux/amd64 --entrypoint /bin/sh "${{ steps.release_meta.outputs.image_ref }}" -lc \
             'command -v pgrep && pgrep --version | head -n 1 && node --version && python3 --version && terraform version | head -n 1'
 
       - run: |
-          docker run --rm --platform linux/arm64 --entrypoint /bin/sh "${{ steps.image.outputs.image_ref }}" -lc \
+          docker run --rm --platform linux/arm64 --entrypoint /bin/sh "${{ steps.release_meta.outputs.image_ref }}" -lc \
             'command -v pgrep && pgrep --version | head -n 1 && node --version && python3 --version && terraform version | head -n 1'
+
+      - if: ${{ inputs.publish_project_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ steps.release_meta.outputs.release_tag }}" >/dev/null 2>&1; then
+            echo "release ${{ steps.release_meta.outputs.release_tag }} already exists" >&2
+            exit 1
+          fi
+
+          gh release create "${{ steps.release_meta.outputs.release_tag }}" \
+            --target "${GITHUB_SHA}" \
+            --title "${{ steps.release_meta.outputs.release_tag }}" \
+            --generate-notes

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,98 @@
+name: Release Image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: release-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish_and_verify:
+    name: publish-and-verify
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      SYNOLOGY_RUNNER_BASE_DIR: /volume1/docker/synology-github-runner
+      COMPOSE_PROJECT_NAME: synology-github-runner
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10.32.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm validate-config -- --config config/pools.yaml --env /tmp/release.env
+
+      - run: SMOKE_PLATFORM=linux/amd64 pnpm smoke-test
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: image
+        run: |
+          node --input-type=module <<'EOF'
+          import fs from "node:fs";
+          import YAML from "yaml";
+
+          const config = YAML.parse(fs.readFileSync("config/pools.yaml", "utf8"));
+          if (!config?.image?.repository || !config?.image?.tag) {
+            throw new Error("config/pools.yaml must define image.repository and image.tag");
+          }
+
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `image_ref=${config.image.repository}:${config.image.tag}\n`
+          );
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `image_tag=${config.image.tag}\n`
+          );
+          EOF
+
+      - run: ./scripts/build-image.sh "${{ steps.image.outputs.image_ref }}" --push
+
+      - run: |
+          docker buildx imagetools inspect "${{ steps.image.outputs.image_ref }}" | tee /tmp/imagetools.txt
+          grep -q "linux/amd64" /tmp/imagetools.txt
+          grep -q "linux/arm64" /tmp/imagetools.txt
+
+      - run: |
+          for attempt in 1 2 3 4 5 6; do
+            if pnpm validate-image -- --config config/pools.yaml --env /tmp/release.env; then
+              exit 0
+            fi
+
+            if [[ "${attempt}" == "6" ]]; then
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+      - run: |
+          docker run --rm --platform linux/amd64 --entrypoint /bin/sh "${{ steps.image.outputs.image_ref }}" -lc \
+            'command -v pgrep && pgrep --version | head -n 1 && node --version && python3 --version && terraform version | head -n 1'
+
+      - run: |
+          docker run --rm --platform linux/arm64 --entrypoint /bin/sh "${{ steps.image.outputs.image_ref }}" -lc \
+            'command -v pgrep && pgrep --version | head -n 1 && node --version && python3 --version && terraform version | head -n 1'

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you set `resources.cpus` or `resources.pidsLimit`, `validate-config` and `ren
 7. Build the runner image:
 
 ```bash
-./scripts/build-image.sh ghcr.io/your-org/synology-github-runner:0.1.3 --push
+./scripts/build-image.sh ghcr.io/your-org/synology-github-runner:0.1.4 --push
 ```
 
 When `--push` is used without an explicit `--platform`, the helper now defaults to `linux/amd64,linux/arm64` so the same tag works across Intel and ARM Synology models. A single-arch tag combined with the wrong `platform` or `architecture` setting will fail at startup with `Exec format error`.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Only point [config/pools.yaml](/Users/johnteneyckjr./src/synology-github-runner/
 - The image keeps the official runner bundle under `/actions-runner` as a read-only source and copies it into a writable per-runner home under `RUNNER_STATE_DIR` before startup.
 - The runner work tree is container-local at `RUNNER_WORK_DIR=/tmp/github-runner-work` so Actions temp extraction does not inherit Synology bind-mount ownership restrictions.
 - The image exposes a dedicated container-local Actions temp directory at `RUNNER_TEMP=/tmp/github-runner-temp` and a hosted tool cache at `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` so `actions/setup-node` and cache-aware shell workflows do not depend on Synology bind-mount ownership semantics.
+- In root-fallback mode, the entrypoint will recreate those container-local runtime directories if Synology rejects an in-place permission refresh, instead of crashing the container during startup.
 - On Synology bind mounts that reject `chown`, the entrypoint falls back to root runner execution with `RUNNER_ALLOW_RUNASROOT=1` so the service can still start cleanly from that writable runner home.
 - The writable-home copy intentionally extracts without restoring archive ownership, so Synology mounts do not emit a `tar: Cannot change ownership ... Operation not permitted` line for every runner file.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ When `--push` is used without an explicit `--platform`, the helper now defaults 
 - Public repos must not receive long-lived secrets from this runner class.
 - GitHub enforces repo access on the runner group side; this repo carries that policy into validation, metadata, and rendered compose output.
 - The image keeps the official runner bundle under `/actions-runner` as a read-only source and copies it into a writable per-runner home under `RUNNER_STATE_DIR` before startup.
+- The runner work tree is container-local at `RUNNER_WORK_DIR=/tmp/github-runner-work` so Actions temp extraction does not inherit Synology bind-mount ownership restrictions.
 - The image exposes a dedicated container-local Actions temp directory at `RUNNER_TEMP=/tmp/github-runner-temp` and a hosted tool cache at `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` so `actions/setup-node` and cache-aware shell workflows do not depend on Synology bind-mount ownership semantics.
 - On Synology bind mounts that reject `chown`, the entrypoint falls back to root runner execution with `RUNNER_ALLOW_RUNASROOT=1` so the service can still start cleanly from that writable runner home.
 - The writable-home copy intentionally extracts without restoring archive ownership, so Synology mounts do not emit a `tar: Cannot change ownership ... Operation not permitted` line for every runner file.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Shell-only, ephemeral GitHub self-hosted runner pools for Synology NAS deploymen
   - `synology-private`
   - `synology-public`
 
-This v1 runner class supports shell jobs, JavaScript actions, composite actions, standard `actions/setup-node` flows, and Terraform CLI workflows. It does not support Docker-based actions, `container:` jobs, or service containers.
+This v1 runner class supports shell jobs, JavaScript actions, composite actions, the bundled shell-safe Node setup action, built-in Python `3.12` workflows, and Terraform CLI workflows. It does not support Docker-based actions, `container:` jobs, or service containers.
 
 ## Repo Layout
 
@@ -107,7 +107,7 @@ If you want the repository release and GHCR image tag to stay aligned, merge the
 - GitHub enforces repo access on the runner group side; this repo carries that policy into validation, metadata, and rendered compose output.
 - The image keeps the official runner bundle under `/actions-runner` as a read-only source and copies it into a writable per-runner home under `RUNNER_STATE_DIR` before startup.
 - The runner work tree is container-local at `RUNNER_WORK_DIR=/tmp/github-runner-work` so Actions temp extraction does not inherit Synology bind-mount ownership restrictions.
-- The image exposes a dedicated container-local Actions temp directory at `RUNNER_TEMP=/tmp/github-runner-temp` and a hosted tool cache at `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` so `actions/setup-node` and cache-aware shell workflows do not depend on Synology bind-mount ownership semantics.
+- The image exposes a dedicated container-local Actions temp directory at `RUNNER_TEMP=/tmp/github-runner-temp` and a hosted tool cache at `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` so shell-safe tool bootstrap actions do not depend on Synology bind-mount ownership semantics.
 - In root-fallback mode, the entrypoint will recreate those container-local runtime directories if Synology rejects an in-place permission refresh, instead of crashing the container during startup.
 - On Synology bind mounts that reject `chown`, the entrypoint falls back to root runner execution with `RUNNER_ALLOW_RUNASROOT=1` so the service can still start cleanly from that writable runner home.
 - The writable-home copy intentionally extracts without restoring archive ownership, so Synology mounts do not emit a `tar: Cannot change ownership ... Operation not permitted` line for every runner file.
@@ -116,6 +116,20 @@ Recommended workflow labels:
 
 - Private repos: `runs-on: [self-hosted, synology, shell-only, private]`
 - Public repos: `runs-on: [self-hosted, synology, shell-only, public]`
+
+## Reusable Setup Actions
+
+For Node projects on shell-only runners, use the bundled action instead of `actions/setup-node`:
+
+```yaml
+- uses: OMT-Global/synology-github-runner/actions/setup-shell-safe-node@main
+  with:
+    node-version: 24.14.1
+```
+
+Use that action on self-hosted Synology runners where `actions/setup-node` would otherwise fail while extracting tool archives. Keep `actions/setup-node` on GitHub-hosted jobs.
+
+For Python projects, the runner image already carries Python `3.12`. Repos that only need `3.12` can run directly on the shell-only pool. Repos with Python version matrices should keep the non-`3.12` lanes on GitHub-hosted runners and only route the `3.12` lane to self-hosted runners.
 
 ## Security Notes
 
@@ -170,7 +184,7 @@ SMOKE_KEEP_ARTIFACTS=1 pnpm smoke-test
 - Verify the generated compose file does not pin `platform:` unless you intentionally forced `architecture`
 - Run a private-repo shell workflow with secrets
 - Run a public-repo shell workflow without secrets
-- Run a self-hosted workflow that uses `actions/setup-node` with `cache: pnpm`
+- Run a self-hosted workflow that uses `OMT-Global/synology-github-runner/actions/setup-shell-safe-node@<ref>`
 - Verify `python3 --version` reports `3.12.x` and `terraform version` reports `1.6.6`
 - Confirm each job de-registers the runner and the service restarts cleanly
 - Confirm there is no Docker socket mount in the rendered compose file

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you set `resources.cpus` or `resources.pidsLimit`, `validate-config` and `ren
 7. Build the runner image:
 
 ```bash
-./scripts/build-image.sh ghcr.io/your-org/synology-github-runner:0.1.5 --push
+./scripts/build-image.sh ghcr.io/your-org/synology-github-runner:0.1.6 --push
 ```
 
 When `--push` is used without an explicit `--platform`, the helper now defaults to `linux/amd64,linux/arm64` so the same tag works across Intel and ARM Synology models. A single-arch tag combined with the wrong `platform` or `architecture` setting will fail at startup with `Exec format error`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Shell-only, ephemeral GitHub self-hosted runner pools for Synology NAS deploymen
 ## What This Repo Builds
 
 - A custom multi-arch runner image based on the official `actions/runner` tarballs
+- Built-in shell-job baseline tooling:
+  - Node.js `18.20.8`
+  - Python `3.12`
+  - Terraform `1.6.6`
+  - `git`, `bash`, `tar`, `zstd`, and `procps`
 - No Docker socket mounts
 - No privileged containers
 - No host-network mode
@@ -12,7 +17,7 @@ Shell-only, ephemeral GitHub self-hosted runner pools for Synology NAS deploymen
   - `synology-private`
   - `synology-public`
 
-This v1 runner class supports shell jobs, JavaScript actions, and composite actions. It does not support Docker-based actions, `container:` jobs, or service containers.
+This v1 runner class supports shell jobs, JavaScript actions, composite actions, standard `actions/setup-node` flows, and Terraform CLI workflows. It does not support Docker-based actions, `container:` jobs, or service containers.
 
 ## Repo Layout
 
@@ -58,7 +63,7 @@ If you set `resources.cpus` or `resources.pidsLimit`, `validate-config` and `ren
 7. Build the runner image:
 
 ```bash
-./scripts/build-image.sh ghcr.io/your-org/synology-github-runner:0.1.4 --push
+./scripts/build-image.sh ghcr.io/your-org/synology-github-runner:0.1.5 --push
 ```
 
 When `--push` is used without an explicit `--platform`, the helper now defaults to `linux/amd64,linux/arm64` so the same tag works across Intel and ARM Synology models. A single-arch tag combined with the wrong `platform` or `architecture` setting will fail at startup with `Exec format error`.
@@ -75,6 +80,7 @@ When `--push` is used without an explicit `--platform`, the helper now defaults 
 - Public repos must not receive long-lived secrets from this runner class.
 - GitHub enforces repo access on the runner group side; this repo carries that policy into validation, metadata, and rendered compose output.
 - The image keeps the official runner bundle under `/actions-runner` as a read-only source and copies it into a writable per-runner home under `RUNNER_STATE_DIR` before startup.
+- The image exposes a dedicated container-local Actions temp directory at `RUNNER_TEMP=/tmp/github-runner-temp` and a hosted tool cache at `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` so `actions/setup-node` and cache-aware shell workflows do not depend on Synology bind-mount ownership semantics.
 - On Synology bind mounts that reject `chown`, the entrypoint falls back to root runner execution with `RUNNER_ALLOW_RUNASROOT=1` so the service can still start cleanly from that writable runner home.
 - The writable-home copy intentionally extracts without restoring archive ownership, so Synology mounts do not emit a `tar: Cannot change ownership ... Operation not permitted` line for every runner file.
 
@@ -135,5 +141,7 @@ SMOKE_KEEP_ARTIFACTS=1 pnpm smoke-test
 - Verify the generated compose file does not pin `platform:` unless you intentionally forced `architecture`
 - Run a private-repo shell workflow with secrets
 - Run a public-repo shell workflow without secrets
+- Run a self-hosted workflow that uses `actions/setup-node` with `cache: pnpm`
+- Verify `python3 --version` reports `3.12.x` and `terraform version` reports `1.6.6`
 - Confirm each job de-registers the runner and the service restarts cleanly
 - Confirm there is no Docker socket mount in the rendered compose file

--- a/README.md
+++ b/README.md
@@ -129,7 +129,17 @@ For Node projects on shell-only runners, use the bundled action instead of `acti
 
 Use that action on self-hosted Synology runners where `actions/setup-node` would otherwise fail while extracting tool archives. Keep `actions/setup-node` on GitHub-hosted jobs.
 
+The shell-only runner image directly supports these job profiles without Docker or service containers:
+
+- Node `18` plus `npm` with `actions/cache`
+- Node `24` when bootstrapped through `OMT-Global/synology-github-runner/actions/setup-shell-safe-node`
+- Python `3.12` plus `pip` with `actions/cache`
+- Terraform `1.6.6` plus plugin-cache directories under `RUNNER_TEMP`
+- Bash/docs validation jobs that only need the standard CLI toolchain
+
 For Python projects, the runner image already carries Python `3.12`. Repos that only need `3.12` can run directly on the shell-only pool. Repos with Python version matrices should keep the non-`3.12` lanes on GitHub-hosted runners and only route the `3.12` lane to self-hosted runners.
+
+For OpenClaw Ouro style workflows, the compatible jobs are the Node/npm validators, docs checks, Python `3.12` linting, Terraform validation, and smoke scripts that stay within bash plus the baked-in toolchain. Keep workflow-parser jobs that rely on extra distro packages, plus any `container:`, `services:`, browser, or Docker-daemon jobs, on GitHub-hosted runners.
 
 ## Security Notes
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Use [release-image.yml](/Users/johnteneyckjr./src/synology-github-runner/.github
 
 The release workflow:
 
+- enforces that `package.json` version matches `config/pools.yaml` image tag
 - validates `config/pools.yaml`
 - runs the local `pnpm smoke-test` contract on `linux/amd64`
 - publishes the configured tag from `config/pools.yaml`
@@ -89,8 +90,11 @@ The release workflow:
 - confirms both `linux/amd64` and `linux/arm64` are present
 - retries `pnpm validate-image` until the GitHub Packages API sees the new tag
 - runs post-publish toolchain checks for both `linux/amd64` and `linux/arm64`
+- can create the matching GitHub release tag `v<version>` when dispatched from `main` with `publish_project_release=true`
 
 Only point [config/pools.yaml](/Users/johnteneyckjr./src/synology-github-runner/config/pools.yaml) at a tag that this workflow has already published and verified.
+
+If you want the repository release and GHCR image tag to stay aligned, merge the version bump to `main` first and then run the release workflow from `main` with `publish_project_release=true`. That will create the repo tag and GitHub Release after the image publish/verify steps succeed.
 
 ## Runtime Contract
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,29 @@ If you set `resources.cpus` or `resources.pidsLimit`, `validate-config` and `ren
 
 When `--push` is used without an explicit `--platform`, the helper now defaults to `linux/amd64,linux/arm64` so the same tag works across Intel and ARM Synology models. A single-arch tag combined with the wrong `platform` or `architecture` setting will fail at startup with `Exec format error`.
 
+Before you deploy a pushed tag, validate that the configured image tag is actually present in GHCR:
+
+```bash
+pnpm validate-image -- --config config/pools.yaml --env .env
+```
+
 8. Deploy the generated compose file to Synology Container Manager and start the stack.
+
+## Publishing A Release Image
+
+Use [release-image.yml](/Users/johnteneyckjr./src/synology-github-runner/.github/workflows/release-image.yml) for published tags instead of relying on an ad hoc local push. The workflow runs on GitHub-hosted runners, not the Synology shell-only pool, because it needs multi-arch Buildx, QEMU, and registry publish support.
+
+The release workflow:
+
+- validates `config/pools.yaml`
+- runs the local `pnpm smoke-test` contract on `linux/amd64`
+- publishes the configured tag from `config/pools.yaml`
+- verifies the pushed tag with `docker buildx imagetools inspect`
+- confirms both `linux/amd64` and `linux/arm64` are present
+- retries `pnpm validate-image` until the GitHub Packages API sees the new tag
+- runs post-publish toolchain checks for both `linux/amd64` and `linux/arm64`
+
+Only point [config/pools.yaml](/Users/johnteneyckjr./src/synology-github-runner/config/pools.yaml) at a tag that this workflow has already published and verified.
 
 ## Runtime Contract
 
@@ -105,6 +127,7 @@ Recommended workflow labels:
 ```bash
 pnpm validate-config -- --config config/pools.yaml --env .env
 pnpm validate-github -- --config config/pools.yaml --env .env
+pnpm validate-image -- --config config/pools.yaml --env .env
 pnpm render-compose -- --config config/pools.yaml --env .env --output docker-compose.generated.yml
 pnpm check-runner-version -- --env .env
 pnpm runner-release-manifest -- --env .env

--- a/actions/setup-shell-safe-node/action.yml
+++ b/actions/setup-shell-safe-node/action.yml
@@ -1,0 +1,46 @@
+name: Setup Shell-Safe Node
+description: Install Node.js on shell-only Linux runners without restoring archive ownership.
+
+inputs:
+  node-version:
+    description: Exact Node.js version to install.
+    required: false
+    default: 24.14.1
+
+runs:
+  using: composite
+  steps:
+    - name: Install Node.js
+      shell: bash
+      env:
+        INPUT_NODE_VERSION: ${{ inputs.node-version }}
+      run: |
+        case "$(uname -s)" in
+          Linux) ;;
+          *)
+            echo "Unsupported runner OS: $(uname -s)" >&2
+            exit 1
+            ;;
+        esac
+
+        case "$(uname -m)" in
+          x86_64) node_arch="x64" ;;
+          aarch64|arm64) node_arch="arm64" ;;
+          *)
+            echo "Unsupported runner architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+        esac
+
+        runner_temp="${RUNNER_TEMP:-/tmp/github-runner-temp}"
+        node_version="${INPUT_NODE_VERSION}"
+        archive="node-v${node_version}-linux-${node_arch}.tar.xz"
+        install_dir="${runner_temp}/node-${node_version}-${node_arch}"
+
+        mkdir -p "${runner_temp}"
+        curl -fsSL "https://nodejs.org/dist/v${node_version}/${archive}" -o "${runner_temp}/${archive}"
+        rm -rf "${install_dir}"
+        mkdir -p "${install_dir}"
+        tar -xJf "${runner_temp}/${archive}" --strip-components=1 --no-same-owner -C "${install_dir}"
+        echo "${install_dir}/bin" >> "$GITHUB_PATH"
+        "${install_dir}/bin/node" --version

--- a/config/pools.yaml
+++ b/config/pools.yaml
@@ -23,6 +23,7 @@ pools:
     runnerGroup: synology-public
     repositoryAccess: selected
     allowedRepositories:
+      - omt-global/axiom
       - omt-global/synology-github-runner
     labels:
       - synology

--- a/config/pools.yaml
+++ b/config/pools.yaml
@@ -1,7 +1,7 @@
 version: 1
 image:
   repository: ghcr.io/omt-global/synology-github-runner
-  tag: 0.1.5
+  tag: 0.1.6
 pools:
   - key: synology-private
     visibility: private

--- a/config/pools.yaml
+++ b/config/pools.yaml
@@ -1,7 +1,7 @@
 version: 1
 image:
   repository: ghcr.io/omt-global/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-private
     visibility: private

--- a/config/pools.yaml
+++ b/config/pools.yaml
@@ -1,7 +1,7 @@
 version: 1
 image:
   repository: ghcr.io/omt-global/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-private
     visibility: private

--- a/config/pools.yaml
+++ b/config/pools.yaml
@@ -28,7 +28,7 @@ pools:
       - synology
       - shell-only
       - public
-    size: 1
+    size: 2
     architecture: auto
     runnerRoot: ${SYNOLOGY_RUNNER_BASE_DIR}/pools/synology-public
     resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 name: synology-github-runner
 services:
   synology-private-runner-01:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.5
+    image: ghcr.io/omt-global/synology-github-runner:0.1.6
     container_name: synology-private-runner-01
     hostname: synology-private-runner-01
     restart: unless-stopped
@@ -40,7 +40,7 @@ services:
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 2g
   synology-private-runner-02:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.5
+    image: ghcr.io/omt-global/synology-github-runner:0.1.6
     container_name: synology-private-runner-02
     hostname: synology-private-runner-02
     restart: unless-stopped
@@ -77,7 +77,7 @@ services:
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 2g
   synology-public-runner-01:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.5
+    image: ghcr.io/omt-global/synology-github-runner:0.1.6
     container_name: synology-public-runner-01
     hostname: synology-public-runner-01
     restart: unless-stopped
@@ -115,7 +115,7 @@ services:
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 1g
   synology-public-runner-02:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.5
+    image: ghcr.io/omt-global/synology-github-runner:0.1.6
     container_name: synology-public-runner-02
     hostname: synology-public-runner-02
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
     labels:
       com.synology-gh-runner.pool: synology-private
       com.synology-gh-runner.visibility: private
@@ -69,6 +71,8 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
     labels:
       com.synology-gh-runner.pool: synology-private
       com.synology-gh-runner.visibility: private
@@ -107,6 +111,8 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
     labels:
       com.synology-gh-runner.pool: synology-public
       com.synology-gh-runner.visibility: public
@@ -145,6 +151,8 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
     labels:
       com.synology-gh-runner.pool: synology-public
       com.synology-gh-runner.visibility: public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,6 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    cap_add:
-      - CHOWN
     labels:
       com.synology-gh-runner.pool: synology-private
       com.synology-gh-runner.visibility: private
@@ -71,8 +69,6 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    cap_add:
-      - CHOWN
     labels:
       com.synology-gh-runner.pool: synology-private
       com.synology-gh-runner.visibility: private
@@ -111,8 +107,6 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    cap_add:
-      - CHOWN
     labels:
       com.synology-gh-runner.pool: synology-public
       com.synology-gh-runner.visibility: public
@@ -151,8 +145,6 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    cap_add:
-      - CHOWN
     labels:
       com.synology-gh-runner.pool: synology-public
       com.synology-gh-runner.visibility: public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 name: synology-github-runner
 services:
   synology-private-runner-01:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.4
+    image: ghcr.io/omt-global/synology-github-runner:0.1.5
     container_name: synology-private-runner-01
     hostname: synology-private-runner-01
     restart: unless-stopped
@@ -21,6 +21,9 @@ services:
       RUNNER_STATE_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-01
       RUNNER_LOG_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-01/logs
       RUNNER_WORK_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-01/_work
+      RUNNER_TEMP: /tmp/github-runner-temp
+      RUNNER_TOOL_CACHE: /opt/hostedtoolcache
+      AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
       RUNNER_EPHEMERAL: "true"
       RUNNER_DISABLE_UPDATE: "true"
     volumes:
@@ -37,7 +40,7 @@ services:
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 2g
   synology-private-runner-02:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.4
+    image: ghcr.io/omt-global/synology-github-runner:0.1.5
     container_name: synology-private-runner-02
     hostname: synology-private-runner-02
     restart: unless-stopped
@@ -55,6 +58,9 @@ services:
       RUNNER_STATE_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-02
       RUNNER_LOG_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-02/logs
       RUNNER_WORK_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-02/_work
+      RUNNER_TEMP: /tmp/github-runner-temp
+      RUNNER_TOOL_CACHE: /opt/hostedtoolcache
+      AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
       RUNNER_EPHEMERAL: "true"
       RUNNER_DISABLE_UPDATE: "true"
     volumes:
@@ -71,7 +77,7 @@ services:
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 2g
   synology-public-runner-01:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.4
+    image: ghcr.io/omt-global/synology-github-runner:0.1.5
     container_name: synology-public-runner-01
     hostname: synology-public-runner-01
     restart: unless-stopped
@@ -89,6 +95,9 @@ services:
       RUNNER_STATE_DIR: /volume2/docker/synology-github-runner/pools/synology-public/runner-01
       RUNNER_LOG_DIR: /volume2/docker/synology-github-runner/pools/synology-public/runner-01/logs
       RUNNER_WORK_DIR: /volume2/docker/synology-github-runner/pools/synology-public/runner-01/_work
+      RUNNER_TEMP: /tmp/github-runner-temp
+      RUNNER_TOOL_CACHE: /opt/hostedtoolcache
+      AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
       RUNNER_EPHEMERAL: "true"
       RUNNER_DISABLE_UPDATE: "true"
       RUNNER_ALLOWED_REPOSITORIES: omt-global/synology-github-runner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
       RUNNER_EPHEMERAL: "true"
       RUNNER_DISABLE_UPDATE: "true"
-      RUNNER_ALLOWED_REPOSITORIES: omt-global/synology-github-runner
+      RUNNER_ALLOWED_REPOSITORIES: omt-global/axiom,omt-global/synology-github-runner
     volumes:
       - /volume2/docker/synology-github-runner/pools/synology-public/runner-01:/volume2/docker/synology-github-runner/pools/synology-public/runner-01
     security_opt:
@@ -111,7 +111,7 @@ services:
       com.synology-gh-runner.pool: synology-public
       com.synology-gh-runner.visibility: public
       com.synology-gh-runner.repository-access: selected
-      com.synology-gh-runner.allowed-repositories: omt-global/synology-github-runner
+      com.synology-gh-runner.allowed-repositories: omt-global/axiom,omt-global/synology-github-runner
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 1g
   synology-public-runner-02:
@@ -138,7 +138,7 @@ services:
       AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
       RUNNER_EPHEMERAL: "true"
       RUNNER_DISABLE_UPDATE: "true"
-      RUNNER_ALLOWED_REPOSITORIES: omt-global/synology-github-runner
+      RUNNER_ALLOWED_REPOSITORIES: omt-global/axiom,omt-global/synology-github-runner
     volumes:
       - /volume2/docker/synology-github-runner/pools/synology-public/runner-02:/volume2/docker/synology-github-runner/pools/synology-public/runner-02
     security_opt:
@@ -149,6 +149,6 @@ services:
       com.synology-gh-runner.pool: synology-public
       com.synology-gh-runner.visibility: public
       com.synology-gh-runner.repository-access: selected
-      com.synology-gh-runner.allowed-repositories: omt-global/synology-github-runner
+      com.synology-gh-runner.allowed-repositories: omt-global/axiom,omt-global/synology-github-runner
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 1g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       RUNNER_REPOSITORY_ACCESS: all
       RUNNER_STATE_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-01
       RUNNER_LOG_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-01/logs
-      RUNNER_WORK_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-01/_work
+      RUNNER_WORK_DIR: /tmp/github-runner-work
       RUNNER_TEMP: /tmp/github-runner-temp
       RUNNER_TOOL_CACHE: /opt/hostedtoolcache
       AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
@@ -57,7 +57,7 @@ services:
       RUNNER_REPOSITORY_ACCESS: all
       RUNNER_STATE_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-02
       RUNNER_LOG_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-02/logs
-      RUNNER_WORK_DIR: /volume2/docker/synology-github-runner/pools/synology-private/runner-02/_work
+      RUNNER_WORK_DIR: /tmp/github-runner-work
       RUNNER_TEMP: /tmp/github-runner-temp
       RUNNER_TOOL_CACHE: /opt/hostedtoolcache
       AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
@@ -94,7 +94,7 @@ services:
       RUNNER_REPOSITORY_ACCESS: selected
       RUNNER_STATE_DIR: /volume2/docker/synology-github-runner/pools/synology-public/runner-01
       RUNNER_LOG_DIR: /volume2/docker/synology-github-runner/pools/synology-public/runner-01/logs
-      RUNNER_WORK_DIR: /volume2/docker/synology-github-runner/pools/synology-public/runner-01/_work
+      RUNNER_WORK_DIR: /tmp/github-runner-work
       RUNNER_TEMP: /tmp/github-runner-temp
       RUNNER_TOOL_CACHE: /opt/hostedtoolcache
       AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,3 +114,41 @@ services:
       com.synology-gh-runner.allowed-repositories: omt-global/synology-github-runner
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 1g
+  synology-public-runner-02:
+    image: ghcr.io/omt-global/synology-github-runner:0.1.5
+    container_name: synology-public-runner-02
+    hostname: synology-public-runner-02
+    restart: unless-stopped
+    stop_grace_period: 2m
+    environment:
+      GITHUB_PAT: ${GITHUB_PAT}
+      GITHUB_API_URL: ${GITHUB_API_URL:-https://api.github.com}
+      GITHUB_ORG: omt-global
+      RUNNER_SCOPE: organization
+      RUNNER_NAME: synology-public-runner-02
+      RUNNER_GROUP: synology-public
+      RUNNER_LABELS: synology,shell-only,public
+      RUNNER_VISIBILITY: public
+      RUNNER_REPOSITORY_ACCESS: selected
+      RUNNER_STATE_DIR: /volume2/docker/synology-github-runner/pools/synology-public/runner-02
+      RUNNER_LOG_DIR: /volume2/docker/synology-github-runner/pools/synology-public/runner-02/logs
+      RUNNER_WORK_DIR: /tmp/github-runner-work
+      RUNNER_TEMP: /tmp/github-runner-temp
+      RUNNER_TOOL_CACHE: /opt/hostedtoolcache
+      AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
+      RUNNER_EPHEMERAL: "true"
+      RUNNER_DISABLE_UPDATE: "true"
+      RUNNER_ALLOWED_REPOSITORIES: omt-global/synology-github-runner
+    volumes:
+      - /volume2/docker/synology-github-runner/pools/synology-public/runner-02:/volume2/docker/synology-github-runner/pools/synology-public/runner-02
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    labels:
+      com.synology-gh-runner.pool: synology-public
+      com.synology-gh-runner.visibility: public
+      com.synology-gh-runner.repository-access: selected
+      com.synology-gh-runner.allowed-repositories: omt-global/synology-github-runner
+      com.synology-gh-runner.shell-only: "true"
+    mem_limit: 1g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 name: synology-github-runner
 services:
   synology-private-runner-01:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.3
+    image: ghcr.io/omt-global/synology-github-runner:0.1.4
     container_name: synology-private-runner-01
     hostname: synology-private-runner-01
     restart: unless-stopped
@@ -37,7 +37,7 @@ services:
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 2g
   synology-private-runner-02:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.3
+    image: ghcr.io/omt-global/synology-github-runner:0.1.4
     container_name: synology-private-runner-02
     hostname: synology-private-runner-02
     restart: unless-stopped
@@ -71,7 +71,7 @@ services:
       com.synology-gh-runner.shell-only: "true"
     mem_limit: 2g
   synology-public-runner-01:
-    image: ghcr.io/omt-global/synology-github-runner:0.1.3
+    image: ghcr.io/omt-global/synology-github-runner:0.1.4
     container_name: synology-public-runner-01
     hostname: synology-public-runner-01
     restart: unless-stopped

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,17 @@
 # syntax=docker/dockerfile:1.7
 
-FROM --platform=$TARGETPLATFORM debian:bookworm-slim
+FROM --platform=$TARGETPLATFORM python:3.12-slim-bookworm
 
 ARG TARGETARCH
 ARG RUNNER_VERSION=2.333.0
+ARG NODE_VERSION=18.20.8
+ARG TERRAFORM_VERSION=1.6.6
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    RUNNER_SOURCE_HOME=/actions-runner
+    RUNNER_SOURCE_HOME=/actions-runner \
+    RUNNER_TEMP=/tmp/github-runner-temp \
+    RUNNER_TOOL_CACHE=/opt/hostedtoolcache \
+    AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -17,12 +22,38 @@ RUN apt-get update \
       gosu \
       jq \
       procps \
+      tar \
       tini \
       unzip \
       xz-utils \
+      zstd \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --create-home --home-dir /home/runner --shell /bin/bash runner
+RUN useradd --create-home --home-dir /home/runner --shell /bin/bash runner \
+    && mkdir -p "${RUNNER_TOOL_CACHE}" "${RUNNER_TEMP}" /opt/node18 \
+    && chown -R runner:runner /home/runner "${RUNNER_TOOL_CACHE}" "${RUNNER_TEMP}" /opt/node18
+
+RUN case "${TARGETARCH}" in \
+      amd64) node_arch="x64"; terraform_arch="amd64" ;; \
+      arm64) node_arch="arm64"; terraform_arch="arm64" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && node_archive="node-v${NODE_VERSION}-linux-${node_arch}.tar.xz" \
+    && curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/${node_archive}" \
+    && curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" \
+    && grep " ${node_archive}\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xJf "${node_archive}" -C /opt/node18 --strip-components=1 --no-same-owner \
+    && ln -sf /opt/node18/bin/corepack /usr/local/bin/corepack \
+    && ln -sf /opt/node18/bin/node /usr/local/bin/node \
+    && ln -sf /opt/node18/bin/npm /usr/local/bin/npm \
+    && ln -sf /opt/node18/bin/npx /usr/local/bin/npx \
+    && rm -f "${node_archive}" SHASUMS256.txt \
+    && terraform_archive="terraform_${TERRAFORM_VERSION}_linux_${terraform_arch}.zip" \
+    && curl -fsSLO "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${terraform_archive}" \
+    && curl -fsSLO "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" \
+    && grep " ${terraform_archive}\$" "terraform_${TERRAFORM_VERSION}_SHA256SUMS" | sha256sum -c - \
+    && unzip -q "${terraform_archive}" -d /usr/local/bin \
+    && rm -f "${terraform_archive}" "terraform_${TERRAFORM_VERSION}_SHA256SUMS"
 
 WORKDIR ${RUNNER_SOURCE_HOME}
 

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -142,11 +142,26 @@ prepare_runtime_dirs() {
   mkdir -p "${RUNNER_WORK_DIR}" "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
 
   if [[ "${runner_exec_mode}" == "root" ]]; then
-    chmod -R u+rwX "${RUNNER_WORK_DIR}" "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
+    ensure_root_runtime_dir "${RUNNER_WORK_DIR}"
+    ensure_root_runtime_dir "${RUNNER_TEMP}"
+    ensure_root_runtime_dir "${RUNNER_TOOL_CACHE}"
     return
   fi
 
   chown -R runner:runner "${RUNNER_WORK_DIR}" "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
+}
+
+ensure_root_runtime_dir() {
+  local dir="$1"
+
+  if chmod -R u+rwX "${dir}" 2>/dev/null; then
+    return
+  fi
+
+  log "runtime directory permission update failed for ${dir}; recreating it for root runner execution"
+  rm -rf "${dir}"
+  mkdir -p "${dir}"
+  chmod -R u+rwX "${dir}"
 }
 
 on_exit() {

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -139,14 +139,14 @@ cleanup_runner() {
 }
 
 prepare_runtime_dirs() {
-  mkdir -p "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
+  mkdir -p "${RUNNER_WORK_DIR}" "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
 
   if [[ "${runner_exec_mode}" == "root" ]]; then
-    chmod -R u+rwX "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
+    chmod -R u+rwX "${RUNNER_WORK_DIR}" "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
     return
   fi
 
-  chown -R runner:runner "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
+  chown -R runner:runner "${RUNNER_WORK_DIR}" "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
 }
 
 on_exit() {

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -84,7 +84,9 @@ cleanup_local_state() {
     "${RUNNER_HOME}/.credentials" \
     "${RUNNER_HOME}/.credentials_rsaparams"
   mkdir -p "${RUNNER_WORK_DIR}"
+  mkdir -p "${RUNNER_TEMP}"
   find "${RUNNER_WORK_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+  find "${RUNNER_TEMP}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 }
 
 prepare_runner_home() {
@@ -136,6 +138,17 @@ cleanup_runner() {
   log "runner registration removed cleanly"
 }
 
+prepare_runtime_dirs() {
+  mkdir -p "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
+
+  if [[ "${runner_exec_mode}" == "root" ]]; then
+    chmod -R u+rwX "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
+    return
+  fi
+
+  chown -R runner:runner "${RUNNER_TEMP}" "${RUNNER_TOOL_CACHE}"
+}
+
 on_exit() {
   runner_exit_code=$?
   cleanup_runner
@@ -159,6 +172,9 @@ require_env RUNNER_WORK_DIR
 : "${RUNNER_DISABLE_UPDATE:=true}"
 : "${RUNNER_REPOSITORY_ACCESS:=selected}"
 : "${RUNNER_HOME:=${RUNNER_STATE_DIR%/}/runner-home}"
+: "${RUNNER_TEMP:=/tmp/github-runner-temp}"
+: "${RUNNER_TOOL_CACHE:=/opt/hostedtoolcache}"
+: "${AGENT_TOOLSDIRECTORY:=${RUNNER_TOOL_CACHE}}"
 : "${RUNNER_EXEC_MODE_OVERRIDE:=}"
 
 if [[ "${RUNNER_SCOPE}" != "organization" ]]; then
@@ -199,6 +215,7 @@ prepare_state_dir() {
 }
 
 prepare_state_dir
+prepare_runtime_dirs
 prepare_runner_home
 
 registration_token="$(request_runner_token registration)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synology-github-runner",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "license": "MIT",
   "description": "Shell-only GitHub self-hosted runner pools for Synology NAS deployments.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synology-github-runner",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "MIT",
   "description": "Shell-only GitHub self-hosted runner pools for Synology NAS deployments.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synology-github-runner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "license": "MIT",
   "description": "Shell-only GitHub self-hosted runner pools for Synology NAS deployments.",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "smoke-test": "bash scripts/smoke-test.sh",
     "test": "vitest run",
     "validate-config": "tsx src/cli.ts validate-config",
-    "validate-github": "tsx src/cli.ts validate-github"
+    "validate-github": "tsx src/cli.ts validate-github",
+    "validate-image": "tsx src/cli.ts validate-image"
   },
   "dependencies": {
     "dotenv": "^17.3.1",

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -23,6 +23,7 @@ PUBLISH_PLATFORM="linux/amd64,linux/arm64"
 PLATFORM="${DEFAULT_PLATFORM}"
 PUSH_FLAG=""
 PLATFORM_WAS_SET=0
+LOAD_FLAG="--load"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -43,9 +44,18 @@ while [[ $# -gt 0 ]]; do
 done
 
 : "${RUNNER_VERSION:=2.333.0}"
+: "${NODE_VERSION:=18.20.8}"
+: "${TERRAFORM_VERSION:=1.6.6}"
 
 if [[ -n "${PUSH_FLAG}" && "${PLATFORM_WAS_SET}" -eq 0 ]]; then
   PLATFORM="${PUBLISH_PLATFORM}"
+fi
+
+if [[ -n "${PUSH_FLAG}" ]]; then
+  LOAD_FLAG=""
+elif [[ "${PLATFORM}" == *,* ]]; then
+  echo "multi-platform builds require --push; local non-pushed builds must target a single platform" >&2
+  exit 1
 fi
 
 cd "${ROOT_DIR}"
@@ -53,7 +63,10 @@ cd "${ROOT_DIR}"
 docker buildx build \
   --platform "${PLATFORM}" \
   --build-arg "RUNNER_VERSION=${RUNNER_VERSION}" \
+  --build-arg "NODE_VERSION=${NODE_VERSION}" \
+  --build-arg "TERRAFORM_VERSION=${TERRAFORM_VERSION}" \
   -f docker/Dockerfile \
   -t "${IMAGE_REF}" \
+  ${LOAD_FLAG:+"${LOAD_FLAG}"} \
   ${PUSH_FLAG:+"${PUSH_FLAG}"} \
   .

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,11 @@ import path from "node:path";
 import { collectConfigWarnings, loadConfig } from "./lib/config.js";
 import { renderCompose } from "./lib/compose.js";
 import { loadDeploymentEnv } from "./lib/env.js";
-import { fetchLatestRunnerRelease, verifyRunnerGroups } from "./lib/github.js";
+import {
+  fetchLatestRunnerRelease,
+  verifyContainerImageTag,
+  verifyRunnerGroups
+} from "./lib/github.js";
 import {
   buildRunnerDownloadUrl,
   summarizeRunnerVersion
@@ -18,6 +22,9 @@ async function main(): Promise<void> {
       break;
     case "validate-github":
       await validateGitHub(args);
+      break;
+    case "validate-image":
+      await validateImage(args);
       break;
     case "render-compose":
       await renderComposeCommand(args);
@@ -115,6 +122,34 @@ async function validateGitHub(args: string[]): Promise<void> {
   );
 }
 
+async function validateImage(args: string[]): Promise<void> {
+  const env = loadDeploymentEnv({
+    envPath: getOption(args, "--env", ".env"),
+    requirePat: true
+  });
+  const configPath = getOption(args, "--config", "config/pools.yaml");
+  const config = loadConfig(configPath!, env);
+  emitWarnings(config);
+  const imageRef = `${config.image.repository}:${config.image.tag}`;
+
+  const match = await verifyContainerImageTag(
+    env.githubApiUrl,
+    env.githubPat!,
+    imageRef
+  );
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ok: true,
+        image: match
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
 async function checkRunnerVersion(args: string[]): Promise<void> {
   const env = loadDeploymentEnv({
     envPath: getOption(args, "--env", ".env"),
@@ -183,6 +218,7 @@ function printUsage(): void {
   process.stderr.write(`Usage:
   pnpm validate-config [--config config/pools.yaml] [--env .env]
   pnpm validate-github [--config config/pools.yaml] [--env .env]
+  pnpm validate-image [--config config/pools.yaml] [--env .env]
   pnpm render-compose [--config config/pools.yaml] [--env .env] [--output docker-compose.generated.yml]
   pnpm check-runner-version [--current 2.333.0] [--env .env]
   pnpm runner-release-manifest [--current 2.333.0] [--env .env]

--- a/src/lib/compose.ts
+++ b/src/lib/compose.ts
@@ -54,6 +54,9 @@ function renderService(pool: PoolConfig, index: number): Record<string, unknown>
     RUNNER_STATE_DIR: runnerStateDir,
     RUNNER_LOG_DIR: `${runnerStateDir}/logs`,
     RUNNER_WORK_DIR: `${runnerStateDir}/_work`,
+    RUNNER_TEMP: "/tmp/github-runner-temp",
+    RUNNER_TOOL_CACHE: "/opt/hostedtoolcache",
+    AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache",
     RUNNER_EPHEMERAL: "true",
     RUNNER_DISABLE_UPDATE: "true"
   };

--- a/src/lib/compose.ts
+++ b/src/lib/compose.ts
@@ -75,7 +75,6 @@ function renderService(pool: PoolConfig, index: number): Record<string, unknown>
     volumes: [`${runnerStateDir}:${runnerStateDir}`],
     security_opt: ["no-new-privileges:true"],
     cap_drop: ["ALL"],
-    cap_add: ["CHOWN"],
     labels: {
       "com.synology-gh-runner.pool": pool.key,
       "com.synology-gh-runner.visibility": pool.visibility,

--- a/src/lib/compose.ts
+++ b/src/lib/compose.ts
@@ -53,7 +53,7 @@ function renderService(pool: PoolConfig, index: number): Record<string, unknown>
     RUNNER_REPOSITORY_ACCESS: pool.repositoryAccess,
     RUNNER_STATE_DIR: runnerStateDir,
     RUNNER_LOG_DIR: `${runnerStateDir}/logs`,
-    RUNNER_WORK_DIR: `${runnerStateDir}/_work`,
+    RUNNER_WORK_DIR: "/tmp/github-runner-work",
     RUNNER_TEMP: "/tmp/github-runner-temp",
     RUNNER_TOOL_CACHE: "/opt/hostedtoolcache",
     AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache",

--- a/src/lib/compose.ts
+++ b/src/lib/compose.ts
@@ -75,6 +75,7 @@ function renderService(pool: PoolConfig, index: number): Record<string, unknown>
     volumes: [`${runnerStateDir}:${runnerStateDir}`],
     security_opt: ["no-new-privileges:true"],
     cap_drop: ["ALL"],
+    cap_add: ["CHOWN"],
     labels: {
       "com.synology-gh-runner.pool": pool.key,
       "com.synology-gh-runner.visibility": pool.visibility,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -43,18 +43,29 @@ export function loadDeploymentEnv(
     );
   }
 
+  const githubApiUrl = normalizeUrl(
+    merged.GITHUB_API_URL || "https://api.github.com"
+  );
+  const synologyRunnerBaseDir =
+    merged.SYNOLOGY_RUNNER_BASE_DIR ||
+    "/volume1/docker/synology-github-runner";
+  const composeProjectName =
+    merged.COMPOSE_PROJECT_NAME || "synology-github-runner";
+  const runnerVersion = normalizeRunnerVersion(merged.RUNNER_VERSION || "2.333.0");
+
   return {
     githubPat,
-    githubApiUrl: normalizeUrl(
-      merged.GITHUB_API_URL || "https://api.github.com"
-    ),
-    synologyRunnerBaseDir:
-      merged.SYNOLOGY_RUNNER_BASE_DIR ||
-      "/volume1/docker/synology-github-runner",
-    composeProjectName:
-      merged.COMPOSE_PROJECT_NAME || "synology-github-runner",
-    runnerVersion: normalizeRunnerVersion(merged.RUNNER_VERSION || "2.333.0"),
-    raw: merged
+    githubApiUrl,
+    synologyRunnerBaseDir,
+    composeProjectName,
+    runnerVersion,
+    raw: {
+      ...merged,
+      GITHUB_API_URL: githubApiUrl,
+      SYNOLOGY_RUNNER_BASE_DIR: synologyRunnerBaseDir,
+      COMPOSE_PROJECT_NAME: composeProjectName,
+      RUNNER_VERSION: runnerVersion
+    }
   };
 }
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -20,6 +20,16 @@ export interface GitHubRunnerGroup {
   isDefault?: boolean;
 }
 
+export interface GitHubContainerImageVersion {
+  imageRef: string;
+  owner: string;
+  packageName: string;
+  tag: string;
+  versionId: number;
+  updatedAt?: string;
+  ownerType: "orgs" | "users";
+}
+
 export interface RunnerGroupExpectation {
   poolKey: string;
   organization: string;
@@ -245,6 +255,133 @@ export async function verifyRunnerGroups(
   });
 }
 
+export async function verifyContainerImageTag(
+  apiUrl: string,
+  token: string,
+  imageRef: string,
+  fetchImpl: FetchLike = fetch as FetchLike
+): Promise<GitHubContainerImageVersion> {
+  const parsed = parseGhcrImageRef(imageRef);
+  const attemptedScopes: Array<"orgs" | "users"> = ["orgs", "users"];
+  const seenTags = new Set<string>();
+
+  for (const ownerType of attemptedScopes) {
+    let sawPackage = false;
+
+    for (let page = 1; page <= 10; page += 1) {
+      const response = await fetchImpl(
+        `${trimApiUrl(apiUrl)}/${ownerType}/${parsed.owner}/packages/container/${encodeURIComponent(
+          parsed.packageName
+        )}/versions?per_page=100&page=${page}`,
+        {
+          method: "GET",
+          headers: buildGitHubApiHeaders(token)
+        }
+      );
+
+      const body = await response.text();
+      if (response.status === 404) {
+        break;
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          `GitHub container package lookup failed for ${imageRef} with ${response.status}: ${body}`
+        );
+      }
+
+      sawPackage = true;
+      const versions = parseContainerPackageVersions(body, imageRef);
+      if (versions.length === 0) {
+        break;
+      }
+
+      for (const version of versions) {
+        for (const versionTag of version.tags) {
+          seenTags.add(versionTag);
+        }
+
+        if (version.tags.includes(parsed.tag)) {
+          return {
+            imageRef,
+            owner: parsed.owner,
+            packageName: parsed.packageName,
+            tag: parsed.tag,
+            versionId: version.id,
+            updatedAt: version.updatedAt,
+            ownerType
+          };
+        }
+      }
+    }
+
+    if (sawPackage) {
+      const availableTags = [...seenTags].sort().join(", ") || "none";
+      throw new Error(
+        `GitHub container package ${parsed.owner}/${parsed.packageName} does not include tag ${parsed.tag}; available tags: ${availableTags}`
+      );
+    }
+  }
+
+  throw new Error(
+    `GitHub container package ${parsed.owner}/${parsed.packageName} was not found for ${imageRef}`
+  );
+}
+
 function trimApiUrl(value: string): string {
   return value.replace(/\/+$/, "");
+}
+
+function parseGhcrImageRef(
+  imageRef: string
+): { owner: string; packageName: string; tag: string } {
+  const match = imageRef.match(/^ghcr\.io\/([^/]+)\/(.+):([^:@/]+)$/);
+
+  if (!match) {
+    throw new Error(
+      `image reference ${imageRef} must match ghcr.io/<owner>/<package>:<tag>`
+    );
+  }
+
+  const [, owner, packageName, tag] = match;
+  return { owner, packageName, tag };
+}
+
+function parseContainerPackageVersions(
+  body: string,
+  imageRef: string
+): Array<{ id: number; updatedAt?: string; tags: string[] }> {
+  const payload = JSON.parse(body) as Array<{
+    id?: number;
+    updated_at?: string;
+    metadata?: {
+      container?: {
+        tags?: string[];
+      };
+    };
+  }>;
+
+  if (!Array.isArray(payload)) {
+    throw new Error(
+      `GitHub container package response for ${imageRef} did not return an array`
+    );
+  }
+
+  return payload.map((version) => {
+    if (typeof version.id !== "number") {
+      throw new Error(
+        `GitHub container package response for ${imageRef} included an invalid version entry`
+      );
+    }
+
+    return {
+      id: version.id,
+      updatedAt: version.updated_at,
+      tags: Array.isArray(version.metadata?.container?.tags)
+        ? version.metadata.container.tags.filter(
+            (tag): tag is string => typeof tag === "string"
+          )
+        : []
+    };
+  });
 }

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { describe, expect, test } from "vitest";
+
+describe("setup-shell-safe-node action", () => {
+  test("downloads Node without restoring archive ownership", () => {
+    const action = YAML.parse(
+      fs.readFileSync(
+        path.resolve("actions/setup-shell-safe-node/action.yml"),
+        "utf8"
+      )
+    ) as {
+      runs: { using: string; steps: Array<Record<string, unknown>> };
+      inputs: Record<string, { default?: string }>;
+    };
+
+    expect(action.runs.using).toBe("composite");
+    expect(action.inputs["node-version"]?.default).toBe("24.14.1");
+
+    const installStep = action.runs.steps.find(
+      (step) => step.name === "Install Node.js"
+    );
+
+    expect(installStep?.shell).toBe("bash");
+    expect(String(installStep?.run)).toContain("https://nodejs.org/dist/");
+    expect(String(installStep?.run)).toContain("--no-same-owner");
+    expect(String(installStep?.run)).toContain('echo "${install_dir}/bin" >> "$GITHUB_PATH"');
+    expect(String(installStep?.run)).toContain('runner_temp="${RUNNER_TEMP:-/tmp/github-runner-temp}"');
+  });
+});

--- a/test/build-script.test.ts
+++ b/test/build-script.test.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+describe("build-image helper", () => {
+  test("loads local single-platform builds and rejects multi-platform non-push builds", () => {
+    const script = fs.readFileSync(
+      path.resolve("scripts/build-image.sh"),
+      "utf8"
+    );
+
+    expect(script).toContain('LOAD_FLAG="--load"');
+    expect(script).toContain('if [[ -n "${PUSH_FLAG}" ]]; then');
+    expect(script).toContain('elif [[ "${PLATFORM}" == *,* ]]; then');
+    expect(script).toContain(
+      "multi-platform builds require --push; local non-pushed builds must target a single platform"
+    );
+  });
+});

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -14,7 +14,8 @@ describe("renderCompose", () => {
     expect(Object.keys(payload.services)).toEqual([
       "synology-private-runner-01",
       "synology-private-runner-02",
-      "synology-public-runner-01"
+      "synology-public-runner-01",
+      "synology-public-runner-02"
     ]);
 
     const privateService = payload.services["synology-private-runner-01"];
@@ -84,7 +85,7 @@ function configFixture(): ResolvedConfig {
         repositoryAccess: "selected",
         allowedRepositories: ["example/public-demo"],
         labels: ["synology", "shell-only", "public"],
-        size: 1,
+        size: 2,
         architecture: "auto",
         runnerRoot: "/volume1/docker/synology-github-runner/pools/synology-public",
         resources: {

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -37,7 +37,6 @@ describe("renderCompose", () => {
     ]);
     expect(privateService.security_opt).toEqual(["no-new-privileges:true"]);
     expect(privateService.cap_drop).toEqual(["ALL"]);
-    expect(privateService.cap_add).toEqual(["CHOWN"]);
     expect(privateService).not.toHaveProperty("init");
     expect(privateService).not.toHaveProperty("platform");
     expect(privateService).not.toHaveProperty("cpus");

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -53,7 +53,7 @@ function configFixture(): ResolvedConfig {
     version: 1,
     image: {
       repository: "ghcr.io/example/synology-github-runner",
-      tag: "0.1.3"
+      tag: "0.1.4"
     },
     pools: [
       {
@@ -70,7 +70,7 @@ function configFixture(): ResolvedConfig {
         resources: {
           memory: "2g"
         },
-        imageRef: "ghcr.io/example/synology-github-runner:0.1.3"
+        imageRef: "ghcr.io/example/synology-github-runner:0.1.4"
       },
       {
         key: "synology-public",
@@ -86,7 +86,7 @@ function configFixture(): ResolvedConfig {
         resources: {
           memory: "1g"
         },
-        imageRef: "ghcr.io/example/synology-github-runner:0.1.3"
+        imageRef: "ghcr.io/example/synology-github-runner:0.1.4"
       }
     ]
   };

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -22,7 +22,10 @@ describe("renderCompose", () => {
       RUNNER_GROUP: "synology-private",
       RUNNER_LABELS: "synology,shell-only,private",
       RUNNER_SCOPE: "organization",
-      RUNNER_REPOSITORY_ACCESS: "all"
+      RUNNER_REPOSITORY_ACCESS: "all",
+      RUNNER_TEMP: "/tmp/github-runner-temp",
+      RUNNER_TOOL_CACHE: "/opt/hostedtoolcache",
+      AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
     });
     expect(privateService.environment).not.toHaveProperty(
       "RUNNER_ALLOWED_REPOSITORIES"
@@ -53,7 +56,7 @@ function configFixture(): ResolvedConfig {
     version: 1,
     image: {
       repository: "ghcr.io/example/synology-github-runner",
-      tag: "0.1.4"
+      tag: "0.1.5"
     },
     pools: [
       {
@@ -70,7 +73,7 @@ function configFixture(): ResolvedConfig {
         resources: {
           memory: "2g"
         },
-        imageRef: "ghcr.io/example/synology-github-runner:0.1.4"
+        imageRef: "ghcr.io/example/synology-github-runner:0.1.5"
       },
       {
         key: "synology-public",
@@ -86,7 +89,7 @@ function configFixture(): ResolvedConfig {
         resources: {
           memory: "1g"
         },
-        imageRef: "ghcr.io/example/synology-github-runner:0.1.4"
+        imageRef: "ghcr.io/example/synology-github-runner:0.1.5"
       }
     ]
   };

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -35,6 +35,9 @@ describe("renderCompose", () => {
     expect(privateService.volumes).toEqual([
       "/volume1/docker/synology-github-runner/pools/synology-private/runner-01:/volume1/docker/synology-github-runner/pools/synology-private/runner-01"
     ]);
+    expect(privateService.security_opt).toEqual(["no-new-privileges:true"]);
+    expect(privateService.cap_drop).toEqual(["ALL"]);
+    expect(privateService.cap_add).toEqual(["CHOWN"]);
     expect(privateService).not.toHaveProperty("init");
     expect(privateService).not.toHaveProperty("platform");
     expect(privateService).not.toHaveProperty("cpus");

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -23,6 +23,7 @@ describe("renderCompose", () => {
       RUNNER_LABELS: "synology,shell-only,private",
       RUNNER_SCOPE: "organization",
       RUNNER_REPOSITORY_ACCESS: "all",
+      RUNNER_WORK_DIR: "/tmp/github-runner-work",
       RUNNER_TEMP: "/tmp/github-runner-temp",
       RUNNER_TOOL_CACHE: "/opt/hostedtoolcache",
       AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -23,7 +23,7 @@ describe("loadConfig", () => {
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-private
     visibility: private
@@ -63,7 +63,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-public
     visibility: public
@@ -94,7 +94,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-private
     visibility: private
@@ -136,7 +136,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-public
     visibility: public
@@ -165,7 +165,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-private
     visibility: private
@@ -196,7 +196,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-private
     visibility: private
@@ -233,7 +233,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-private
     visibility: private
@@ -269,7 +269,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.4
+  tag: 0.1.5
 pools:
   - key: synology-private
     visibility: private

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -23,7 +23,7 @@ describe("loadConfig", () => {
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-private
     visibility: private
@@ -63,7 +63,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-public
     visibility: public
@@ -94,7 +94,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-private
     visibility: private
@@ -136,7 +136,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-public
     visibility: public
@@ -165,7 +165,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-private
     visibility: private
@@ -196,7 +196,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-private
     visibility: private
@@ -233,7 +233,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-private
     visibility: private
@@ -269,7 +269,7 @@ pools:
       `version: 1
 image:
   repository: ghcr.io/example/synology-github-runner
-  tag: 0.1.3
+  tag: 0.1.4
 pools:
   - key: synology-private
     visibility: private

--- a/test/dockerfile.test.ts
+++ b/test/dockerfile.test.ts
@@ -12,4 +12,24 @@ describe("Dockerfile packaging", () => {
     expect(dockerfile).toContain('CMD pgrep -f "Runner.Listener" > /dev/null || exit 1');
     expect(dockerfile).toMatch(/\bprocps\b/);
   });
+
+  test("pins the shell-runner toolchain and Actions cache paths", () => {
+    const dockerfile = fs.readFileSync(
+      path.resolve("docker/Dockerfile"),
+      "utf8"
+    );
+
+    expect(dockerfile).toContain("FROM --platform=$TARGETPLATFORM python:3.12-slim-bookworm");
+    expect(dockerfile).toContain("ARG NODE_VERSION=18.20.8");
+    expect(dockerfile).toContain("ARG TERRAFORM_VERSION=1.6.6");
+    expect(dockerfile).toContain("RUNNER_TEMP=/tmp/github-runner-temp");
+    expect(dockerfile).toContain("RUNNER_TOOL_CACHE=/opt/hostedtoolcache");
+    expect(dockerfile).toContain("AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache");
+    expect(dockerfile).toMatch(/\btar\b/);
+    expect(dockerfile).toMatch(/\bzstd\b/);
+    expect(dockerfile).toContain("node-v${NODE_VERSION}-linux-${node_arch}.tar.xz");
+    expect(dockerfile).toContain(
+      "terraform_${TERRAFORM_VERSION}_linux_${terraform_arch}.zip"
+    );
+  });
 });

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+describe("runner entrypoint", () => {
+  test("recreates container-local runtime directories when root-mode chmod fails", () => {
+    const script = fs.readFileSync(
+      path.resolve("docker/runner-entrypoint.sh"),
+      "utf8"
+    );
+
+    expect(script).toContain('ensure_root_runtime_dir "${RUNNER_WORK_DIR}"');
+    expect(script).toContain('ensure_root_runtime_dir "${RUNNER_TEMP}"');
+    expect(script).toContain('ensure_root_runtime_dir "${RUNNER_TOOL_CACHE}"');
+    expect(script).toContain(
+      'log "runtime directory permission update failed for ${dir}; recreating it for root runner execution"'
+    );
+    expect(script).toContain('rm -rf "${dir}"');
+  });
+});

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -6,6 +6,34 @@ import { loadDeploymentEnv } from "../src/lib/env.js";
 
 const tempPaths: string[] = [];
 
+function withEnv<T>(
+  overrides: Record<string, string | undefined>,
+  callback: () => T
+): T {
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(overrides)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 afterEach(() => {
   for (const tempPath of tempPaths.splice(0)) {
     fs.rmSync(tempPath, { recursive: true, force: true });
@@ -14,10 +42,16 @@ afterEach(() => {
 
 describe("loadDeploymentEnv", () => {
   test("loads defaults when no .env file exists", () => {
-    const env = loadDeploymentEnv({
-      envPath: "/nonexistent/.env",
-      requirePat: false
-    });
+    const env = withEnv(
+      {
+        GITHUB_PAT: undefined
+      },
+      () =>
+        loadDeploymentEnv({
+          envPath: "/nonexistent/.env",
+          requirePat: false
+        })
+    );
 
     expect(env.githubApiUrl).toBe("https://api.github.com");
     expect(env.composeProjectName).toBe("synology-github-runner");
@@ -27,10 +61,16 @@ describe("loadDeploymentEnv", () => {
 
   test("throws when GITHUB_PAT is required but missing", () => {
     expect(() =>
-      loadDeploymentEnv({
-        envPath: "/nonexistent/.env",
-        requirePat: true
-      })
+      withEnv(
+        {
+          GITHUB_PAT: undefined
+        },
+        () =>
+          loadDeploymentEnv({
+            envPath: "/nonexistent/.env",
+            requirePat: true
+          })
+      )
     ).toThrow(/GITHUB_PAT is required/);
   });
 
@@ -45,7 +85,12 @@ describe("loadDeploymentEnv", () => {
       "utf8"
     );
 
-    const env = loadDeploymentEnv({ envPath, requirePat: true });
+    const env = withEnv(
+      {
+        GITHUB_PAT: undefined
+      },
+      () => loadDeploymentEnv({ envPath, requirePat: true })
+    );
     expect(env.githubPat).toBe("test-token");
     expect(env.runnerVersion).toBe("2.340.0");
   });
@@ -54,20 +99,20 @@ describe("loadDeploymentEnv", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "synology-env-"));
     tempPaths.push(directory);
     const envPath = path.join(directory, ".env");
-    const previousGithubApiUrl = process.env.GITHUB_API_URL;
 
     fs.writeFileSync(envPath, "GITHUB_API_URL=https://ghe.example.com/api/v3///\n", "utf8");
-    delete process.env.GITHUB_API_URL;
 
-    try {
-      const env = loadDeploymentEnv({ envPath, requirePat: false });
-      expect(env.githubApiUrl).toBe("https://ghe.example.com/api/v3");
-    } finally {
-      if (previousGithubApiUrl === undefined) {
-        delete process.env.GITHUB_API_URL;
-      } else {
-        process.env.GITHUB_API_URL = previousGithubApiUrl;
-      }
-    }
+    const env = withEnv(
+      {
+        GITHUB_API_URL: undefined
+      },
+      () =>
+        loadDeploymentEnv({
+          envPath,
+          requirePat: false
+        })
+    );
+
+    expect(env.githubApiUrl).toBe("https://ghe.example.com/api/v3");
   });
 });

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -57,6 +57,12 @@ describe("loadDeploymentEnv", () => {
     expect(env.composeProjectName).toBe("synology-github-runner");
     expect(env.runnerVersion).toBe("2.333.0");
     expect(env.githubPat).toBeUndefined();
+    expect(env.raw).toMatchObject({
+      GITHUB_API_URL: "https://api.github.com",
+      SYNOLOGY_RUNNER_BASE_DIR: "/volume1/docker/synology-github-runner",
+      COMPOSE_PROJECT_NAME: "synology-github-runner",
+      RUNNER_VERSION: "2.333.0"
+    });
   });
 
   test("throws when GITHUB_PAT is required but missing", () => {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -5,6 +5,7 @@ import {
   fetchOrganizationRunnerGroups,
   fetchLatestRunnerRelease,
   fetchRunnerToken,
+  verifyContainerImageTag,
   verifyRunnerGroups
 } from "../src/lib/github.js";
 
@@ -241,5 +242,106 @@ describe("github runner API helpers", () => {
     await expect(
       fetchLatestRunnerRelease("https://api.github.com", "secret", fetchMock)
     ).rejects.toThrow(/failed with 404/);
+  });
+
+  test("verifies a published GHCR tag through the organization package API", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify([
+          {
+            id: 101,
+            updated_at: "2026-03-28T16:29:47Z",
+            metadata: {
+              container: {
+                tags: ["0.1.5", "latest"]
+              }
+            }
+          }
+        ])
+    });
+
+    await expect(
+      verifyContainerImageTag(
+        "https://api.github.com",
+        "secret",
+        "ghcr.io/omt-global/synology-github-runner:0.1.5",
+        fetchMock
+      )
+    ).resolves.toEqual({
+      imageRef: "ghcr.io/omt-global/synology-github-runner:0.1.5",
+      owner: "omt-global",
+      packageName: "synology-github-runner",
+      tag: "0.1.5",
+      versionId: 101,
+      updatedAt: "2026-03-28T16:29:47Z",
+      ownerType: "orgs"
+    });
+  });
+
+  test("falls back to user package lookup when org scope is missing", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => "Not Found"
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify([
+            {
+              id: 77,
+              metadata: {
+                container: {
+                  tags: ["0.1.5"]
+                }
+              }
+            }
+          ])
+      });
+
+    await expect(
+      verifyContainerImageTag(
+        "https://api.github.com",
+        "secret",
+        "ghcr.io/jmcte/synology-github-runner:0.1.5",
+        fetchMock
+      )
+    ).resolves.toMatchObject({
+      owner: "jmcte",
+      ownerType: "users",
+      versionId: 77
+    });
+  });
+
+  test("fails when the package exists but the configured tag is missing", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify([
+          {
+            id: 101,
+            metadata: {
+              container: {
+                tags: ["0.1.4", "latest"]
+              }
+            }
+          }
+        ])
+    });
+
+    await expect(
+      verifyContainerImageTag(
+        "https://api.github.com",
+        "secret",
+        "ghcr.io/omt-global/synology-github-runner:0.1.5",
+        fetchMock
+      )
+    ).rejects.toThrow(/does not include tag 0\.1\.5; available tags: 0\.1\.4, latest/);
   });
 });

--- a/test/release-contract.test.ts
+++ b/test/release-contract.test.ts
@@ -1,0 +1,21 @@
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { describe, expect, test } from "vitest";
+
+describe("release contract", () => {
+  test("keeps the package version aligned with the configured image tag", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.resolve("package.json"), "utf8")
+    ) as { version: string };
+    const config = YAML.parse(
+      fs.readFileSync(path.resolve("config/pools.yaml"), "utf8")
+    ) as {
+      image: {
+        tag: string;
+      };
+    };
+
+    expect(packageJson.version).toBe(config.image.tag);
+  });
+});

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -4,7 +4,7 @@ import YAML from "yaml";
 import { describe, expect, test } from "vitest";
 
 describe("release workflow", () => {
-  test("publishes on hosted runners and verifies the pushed tag", () => {
+  test("publishes on hosted runners, verifies the pushed tag, and can create a repo release from main", () => {
     const workflow = YAML.parse(
       fs.readFileSync(
         path.resolve(".github/workflows/release-image.yml"),
@@ -25,16 +25,23 @@ describe("release workflow", () => {
 
     const job = workflow.jobs.publish_and_verify;
     const steps = job.steps;
+    const dispatch = workflow.on.workflow_dispatch as {
+      inputs?: Record<string, { type?: string; default?: boolean }>;
+    };
 
     expect(workflow.on).toHaveProperty("workflow_dispatch");
     expect(workflow.permissions).toMatchObject({
-      contents: "read",
+      contents: "write",
       packages: "write"
     });
     expect(job["runs-on"]).toBe("ubuntu-latest");
     expect(job.env).toMatchObject({
       GITHUB_PAT: "${{ secrets.GITHUB_TOKEN }}",
       SYNOLOGY_RUNNER_BASE_DIR: "/volume1/docker/synology-github-runner"
+    });
+    expect(dispatch.inputs?.publish_project_release).toMatchObject({
+      type: "boolean",
+      default: false
     });
 
     expect(steps.some((step) => step.uses === "docker/setup-qemu-action@v4")).toBe(
@@ -69,6 +76,23 @@ describe("release workflow", () => {
       )
     ).toBe(true);
     expect(
+      steps.some(
+        (step) =>
+          typeof step.run === "string" &&
+          step.run.includes("package.json version") &&
+          step.run.includes("config image tag")
+      )
+    ).toBe(true);
+    expect(
+      steps.some(
+        (step) =>
+          step.if === "${{ inputs.publish_project_release }}" &&
+          typeof step.run === "string" &&
+          step.run.includes('GITHUB_REF_NAME') &&
+          step.run.includes("main")
+      )
+    ).toBe(true);
+    expect(
       steps.filter(
         (step) =>
           typeof step.run === "string" &&
@@ -76,5 +100,14 @@ describe("release workflow", () => {
           step.run.includes("terraform version")
       )
     ).toHaveLength(2);
+    expect(
+      steps.some(
+        (step) =>
+          step.if === "${{ inputs.publish_project_release }}" &&
+          typeof step.run === "string" &&
+          step.run.includes("gh release create") &&
+          step.run.includes("--generate-notes")
+      )
+    ).toBe(true);
   });
 });

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { describe, expect, test } from "vitest";
+
+describe("release workflow", () => {
+  test("publishes on hosted runners and verifies the pushed tag", () => {
+    const workflow = YAML.parse(
+      fs.readFileSync(
+        path.resolve(".github/workflows/release-image.yml"),
+        "utf8"
+      )
+    ) as {
+      on: Record<string, unknown>;
+      permissions: Record<string, string>;
+      jobs: Record<
+        string,
+        {
+          "runs-on": string;
+          env: Record<string, string>;
+          steps: Array<Record<string, unknown>>;
+        }
+      >;
+    };
+
+    const job = workflow.jobs.publish_and_verify;
+    const steps = job.steps;
+
+    expect(workflow.on).toHaveProperty("workflow_dispatch");
+    expect(workflow.permissions).toMatchObject({
+      contents: "read",
+      packages: "write"
+    });
+    expect(job["runs-on"]).toBe("ubuntu-latest");
+    expect(job.env).toMatchObject({
+      GITHUB_PAT: "${{ secrets.GITHUB_TOKEN }}",
+      SYNOLOGY_RUNNER_BASE_DIR: "/volume1/docker/synology-github-runner"
+    });
+
+    expect(steps.some((step) => step.uses === "docker/setup-qemu-action@v4")).toBe(
+      true
+    );
+    expect(steps.some((step) => step.uses === "docker/setup-buildx-action@v3")).toBe(
+      true
+    );
+    expect(steps.some((step) => step.uses === "docker/login-action@v4")).toBe(true);
+    expect(
+      steps.some(
+        (step) =>
+          typeof step.run === "string" &&
+          step.run.includes("./scripts/build-image.sh") &&
+          step.run.includes("--push")
+      )
+    ).toBe(true);
+    expect(
+      steps.some(
+        (step) =>
+          typeof step.run === "string" &&
+          step.run.includes("docker buildx imagetools inspect") &&
+          step.run.includes("linux/amd64") &&
+          step.run.includes("linux/arm64")
+      )
+    ).toBe(true);
+    expect(
+      steps.some(
+        (step) =>
+          typeof step.run === "string" &&
+          step.run.includes("pnpm validate-image")
+      )
+    ).toBe(true);
+    expect(
+      steps.filter(
+        (step) =>
+          typeof step.run === "string" &&
+          step.run.includes("command -v pgrep") &&
+          step.run.includes("terraform version")
+      )
+    ).toHaveLength(2);
+  });
+});

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { describe, expect, test } from "vitest";
+
+describe("CI workflow", () => {
+  test("keeps trusted shell jobs on the public self-hosted runner contract", () => {
+    const workflow = YAML.parse(
+      fs.readFileSync(path.resolve(".github/workflows/ci.yml"), "utf8")
+    ) as {
+      jobs: Record<string, Record<string, unknown>>;
+    };
+
+    const trustedJob = workflow.jobs.test_self_hosted_trusted;
+    const steps = trustedJob.steps as Array<Record<string, unknown>>;
+    const setupNodeStep = steps.find(
+      (step) => step.uses === "actions/setup-node@v6"
+    );
+
+    expect(trustedJob["runs-on"]).toEqual([
+      "self-hosted",
+      "synology",
+      "shell-only",
+      "public"
+    ]);
+    expect(trustedJob.env).toMatchObject({
+      RUNNER_TEMP: "/tmp/github-runner-temp",
+      RUNNER_TOOL_CACHE: "/opt/hostedtoolcache",
+      AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
+    });
+    expect(setupNodeStep).toBeDefined();
+    expect(setupNodeStep?.with).toMatchObject({
+      "node-version": "24",
+      cache: "pnpm"
+    });
+    expect(JSON.stringify(steps)).not.toContain("https://nodejs.org/dist/");
+  });
+
+  test("keeps fork pull requests on GitHub-hosted runners", () => {
+    const workflow = YAML.parse(
+      fs.readFileSync(path.resolve(".github/workflows/ci.yml"), "utf8")
+    ) as {
+      jobs: Record<string, Record<string, unknown>>;
+    };
+
+    expect(workflow.jobs.test_public_fork_pr["runs-on"]).toBe("ubuntu-latest");
+  });
+});

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -47,6 +47,53 @@ describe("CI workflow", () => {
     });
   });
 
+  test("verifies the broader shell-safe toolchain contract on self-hosted runners", () => {
+    const workflow = YAML.parse(
+      fs.readFileSync(path.resolve(".github/workflows/ci.yml"), "utf8")
+    ) as {
+      jobs: Record<string, Record<string, unknown>>;
+    };
+
+    const contractJob = workflow.jobs.shell_safe_contract_trusted;
+    const steps = contractJob.steps as Array<Record<string, unknown>>;
+    const cacheStep = steps.find((step) => step.uses === "actions/cache@v4");
+    const verifyToolchainStep = steps.find(
+      (step) => step.name === "Verify built-in shell-safe toolchain"
+    );
+    const verifyCacheStep = steps.find(
+      (step) => step.name === "Verify cache-aware commands"
+    );
+
+    expect(contractJob["runs-on"]).toEqual([
+      "self-hosted",
+      "synology",
+      "shell-only",
+      "public"
+    ]);
+    expect(contractJob.env).toMatchObject({
+      RUNNER_TEMP: "/tmp/github-runner-temp",
+      RUNNER_TOOL_CACHE: "/opt/hostedtoolcache",
+      AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache",
+      TF_PLUGIN_CACHE_DIR: "/tmp/github-runner-temp/terraform-plugin-cache"
+    });
+    expect(cacheStep?.with).toMatchObject({
+      key: "${{ runner.os }}-shell-safe-contract-${{ hashFiles('docker/Dockerfile', '.github/workflows/ci.yml') }}"
+    });
+    expect(String(cacheStep?.with?.path)).toContain(".tmp/ci-shell-safe/npm");
+    expect(String(cacheStep?.with?.path)).toContain(".tmp/ci-shell-safe/pip");
+    expect(String(cacheStep?.with?.path)).toContain(
+      "${{ env.TF_PLUGIN_CACHE_DIR }}"
+    );
+    expect(String(verifyToolchainStep?.run)).toContain("node --version");
+    expect(String(verifyToolchainStep?.run)).toContain("python3.12 --version");
+    expect(String(verifyToolchainStep?.run)).toContain("terraform version");
+    expect(String(verifyCacheStep?.run)).toContain("python3.12 -m venv .venv-contract");
+    expect(String(verifyCacheStep?.run)).toContain("npm config get cache");
+    expect(String(verifyCacheStep?.run)).toContain(
+      "terraform -chdir=.tmp/ci-shell-safe/terraform init -backend=false"
+    );
+  });
+
   test("keeps fork pull requests on GitHub-hosted runners", () => {
     const workflow = YAML.parse(
       fs.readFileSync(path.resolve(".github/workflows/ci.yml"), "utf8")

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -13,7 +13,9 @@ describe("CI workflow", () => {
 
     const trustedJob = workflow.jobs.test_self_hosted_trusted;
     const steps = trustedJob.steps as Array<Record<string, unknown>>;
-    const installNodeStep = steps.find((step) => step.name === "Install Node.js");
+    const installNodeStep = steps.find(
+      (step) => step.uses === "./actions/setup-shell-safe-node"
+    );
     const forkSteps = workflow.jobs.test_public_fork_pr.steps as Array<
       Record<string, unknown>
     >;
@@ -33,11 +35,9 @@ describe("CI workflow", () => {
       AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
     });
     expect(installNodeStep).toBeDefined();
-    expect(String(installNodeStep?.run)).toContain('node_version="24.14.1"');
-    expect(String(installNodeStep?.run)).toContain("--no-same-owner");
-    expect(
-      String(installNodeStep?.run)
-    ).toContain('echo "${install_dir}/bin" >> "$GITHUB_PATH"');
+    expect(installNodeStep?.with).toMatchObject({
+      "node-version": "24.14.1"
+    });
     expect(steps.some((step) => step.uses === "actions/setup-node@v6")).toBe(
       false
     );
@@ -45,7 +45,6 @@ describe("CI workflow", () => {
       "node-version": "24",
       cache: "pnpm"
     });
-    expect(String(installNodeStep?.run)).toContain("https://nodejs.org/dist/");
   });
 
   test("keeps fork pull requests on GitHub-hosted runners", () => {

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -13,7 +13,11 @@ describe("CI workflow", () => {
 
     const trustedJob = workflow.jobs.test_self_hosted_trusted;
     const steps = trustedJob.steps as Array<Record<string, unknown>>;
-    const setupNodeStep = steps.find(
+    const installNodeStep = steps.find((step) => step.name === "Install Node.js");
+    const forkSteps = workflow.jobs.test_public_fork_pr.steps as Array<
+      Record<string, unknown>
+    >;
+    const forkSetupNodeStep = forkSteps.find(
       (step) => step.uses === "actions/setup-node@v6"
     );
 
@@ -28,12 +32,20 @@ describe("CI workflow", () => {
       RUNNER_TOOL_CACHE: "/opt/hostedtoolcache",
       AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
     });
-    expect(setupNodeStep).toBeDefined();
-    expect(setupNodeStep?.with).toMatchObject({
+    expect(installNodeStep).toBeDefined();
+    expect(String(installNodeStep?.run)).toContain('node_version="24.14.1"');
+    expect(String(installNodeStep?.run)).toContain("--no-same-owner");
+    expect(
+      String(installNodeStep?.run)
+    ).toContain('echo "${install_dir}/bin" >> "$GITHUB_PATH"');
+    expect(steps.some((step) => step.uses === "actions/setup-node@v6")).toBe(
+      false
+    );
+    expect(forkSetupNodeStep?.with).toMatchObject({
       "node-version": "24",
       cache: "pnpm"
     });
-    expect(JSON.stringify(steps)).not.toContain("https://nodejs.org/dist/");
+    expect(String(installNodeStep?.run)).toContain("https://nodejs.org/dist/");
   });
 
   test("keeps fork pull requests on GitHub-hosted runners", () => {


### PR DESCRIPTION
## Summary

- bump the published runner image tag from `0.1.3` to `0.1.4`
- update config, rendered compose, docs, and test fixtures to the new tag
- route trusted CI runs to the public self-hosted Synology runners while keeping public fork PRs on GitHub-hosted runners

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm validate-config -- --config config/pools.yaml --env .env`
- [x] `pnpm validate-github -- --config config/pools.yaml --env .env`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`

## Synology / GitHub Impact

- [ ] no deploy impact
- [x] compose/config change
- [x] image rebuild or republish required
- [x] GitHub settings or runner-group change required
