### PR TITLE
Bootstrap Codex and Claude project setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "synology-github-runner Claude Code",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "24.14.1"
+    }
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
+  ],
+  "postCreateCommand": "bash scripts/claude/setup-devcontainer.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,73 @@
+name: Claude Code
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Task for Claude to run in this repository'
+        required: true
+        default: 'Review the current branch changes for bugs, CI regressions, and missing tests.'
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: claude-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  claude:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Require Claude auth
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ -z "${ANTHROPIC_API_KEY}" ]]; then
+            echo "Missing repository secret ANTHROPIC_API_KEY. Run /install-github-app in Claude Code or add the secret before using this workflow." >&2
+            exit 1
+          fi
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          use_sticky_comment: true
+          additional_permissions: "actions: read"
+          prompt: |
+            REPO: ${{ github.repository }}
+            DEFAULT BRANCH: main
+
+            Use CLAUDE.md and docs/bootstrap/onboarding.md as repo policy context.
+            Keep required PR status checks aligned with test.
+            Preserve the split fast and extended validation model.
+            Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
+            Docker, service-container, browser, and `container:` jobs stay on GitHub-hosted runners.
+            Prefer the smallest safe change and add tests for behavior changes.
+
+            MANUAL TASK: ${{ github.event.inputs.prompt }}
+            If this is not a manual run, ignore the MANUAL TASK line and respond to the current `@claude` request instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS
+
+- Always work on a feature branch. Hooks block commits to `main` and `master`; enable them with `git config core.hooksPath .githooks`.
+- Stack baseline: Node.js + TypeScript.
+- CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on `main`, nightly, or manual dispatch.
+- Self-hosted runner policy: shell-safe jobs may use `[self-hosted, synology, shell-only, public]`; anything needing Docker, service containers, browser infra, or `container:` must stay on GitHub-hosted runners.
+- Add or update tests for every interactive, branching, or operator-facing behavior change.
+- Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.
+
+## Local Conventions
+
+- Keep scope tight and favor predictable templates over clever scaffolding.
+- Treat `project.bootstrap.yaml` as the source of truth for repo governance, environments, CI policy, and home profile sync.
+- Review `docs/bootstrap/onboarding.md` before first merge to confirm reviewers, runner labels, and environment gates match the project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+    # CLAUDE.md
+
+    ## Project Map
+
+    - `project.bootstrap.yaml`: source of truth for bootstrap policy
+- `.github/workflows/`: generated fast and extended CI lanes
+- `scripts/claude-cloud/setup.sh`: first-party Claude Code on the web setup script
+- `.github/workflows/claude.yml`: opt-in Claude GitHub Action for manual or `@claude` review flows
+- `.devcontainer/devcontainer.json`: interactive Claude Code workspace baseline
+- `.github/workflows/`: repo CI and review workflows
+- `scripts/ci/`: bootstrap CI entrypoints when this repo uses the generated workflow lane
+- `scripts/claude/setup-devcontainer.sh`: installs repo dependencies inside the devcontainer
+- `.githooks/pre-commit`: branch and env-file guardrail when local hooks are bootstrap-managed
+- `docs/bootstrap/onboarding.md`: operator checklist for repo/governance setup
+- `docs/bootstrap/claude-environment.md`: Claude setup guide for hosted, interactive, and GitHub-hosted use
+
+    ## Guardrails
+
+    - Keep `test` as the single required PR status check.
+- Use one approval plus code owners on `main` unless the manifest explicitly changes it.
+- `stage` and `prod` environments require reviewers and prevent self-review by default.
+- Home-level Codex and Claude profile sync is managed by the bootstrap tool, not by ad-hoc manual edits.
+- Claude Code on the web should use the repo-managed setup script and keep network access limited by default.
+- The generated Claude GitHub Action is a separate review lane. It must not become a required status check.
+- Treat the devcontainer as a trusted-repo workspace. Do not mount extra secrets beyond the persisted `~/.claude` profile unless you explicitly need them.

--- a/docs/bootstrap/claude-environment.md
+++ b/docs/bootstrap/claude-environment.md
@@ -1,0 +1,56 @@
+    # Claude Environment
+
+    Claude Code on the web provides a first-party cloud environment comparable to Codex Web. This bootstrap prepares the hosted path first, then adds optional local and GitHub-native alternatives:
+
+    - First-party hosted sessions at `claude.ai/code`
+- Interactive containerized work with `.devcontainer/devcontainer.json`
+- GitHub-hosted automation with `.github/workflows/claude.yml`
+
+## Claude Code On The Web
+
+- Hosted entrypoint: `https://claude.ai/code`
+- Repo: `OMT-Global/synology-github-runner`
+- Setup script: `bash scripts/claude-cloud/setup.sh`
+- Network access: start with limited access; only expand it when a task truly needs more than registries and GitHub
+- Environment variables: configure them in the Claude environment UI as `.env`-style key-value pairs
+- GitHub integration: connect GitHub, install the Claude GitHub App, then pick this repo as an allowed target
+- Repo guidance: Claude on the web reads `CLAUDE.md` from the repository
+
+## Teleport And Remote Sessions
+
+- Start a hosted task from the terminal with `claude --remote "your task"`
+- Pull a hosted session back into the terminal with `claude --teleport`
+- Hosted tasks clone the default branch unless you specify a branch in the prompt
+- Teleport requires a clean git state and the same repository/account pairing
+
+## Interactive Devcontainer
+
+- Open the repo in a devcontainer-capable editor and reopen in container.
+- The container installs the Claude Code feature plus repo dependencies via `bash scripts/claude/setup-devcontainer.sh`.
+- `~/.claude` is mounted into the container so Claude Code auth persists between sessions.
+- Only use this with trusted repositories. Mounted Claude credentials are available inside the container.
+
+## GitHub Action
+
+- Workflow file: `.github/workflows/claude.yml`
+- Runner: `ubuntu-latest`
+- Triggers:
+  - manual `workflow_dispatch`
+  - PR or issue comments containing `@claude`
+  - review comments or review bodies containing `@claude`
+- Auth:
+  - preferred: run `/install-github-app` in Claude Code as a repo admin
+  - fallback: add a repository secret named `ANTHROPIC_API_KEY`
+
+    ## Guardrails
+
+    - Keep the Claude workflow out of the required PR check set. The required checks are `test`.
+- Prefer Claude Code on the web for long-running async review or fix tasks; use the devcontainer when you need a local interactive container.
+- Treat the devcontainer as a trusted-repo workspace because the mounted `~/.claude` profile is available inside the container.
+- Do not relax the action to allow non-write users on public repos unless you intentionally accept the prompt-injection risk.
+- Keep Claude review and automation on GitHub-hosted runners; do not move it onto the self-hosted shell-only fleet.
+
+    ## Project
+
+    - Repository: `OMT-Global/synology-github-runner`
+    - Default branch: `main`

--- a/docs/bootstrap/codex-cloud-environment.md
+++ b/docs/bootstrap/codex-cloud-environment.md
@@ -1,0 +1,17 @@
+# Codex Cloud Environment
+
+Configure the Codex Web environment in Codex settings for:
+
+- Repo: `OMT-Global/synology-github-runner`
+- Base image: `universal`
+- Setup mode: manual setup script
+- Setup script: `bash scripts/codex-cloud/setup.sh`
+- Maintenance script: `bash scripts/codex-cloud/maintenance.sh`
+- Agent internet access: off by default; enable limited or unrestricted access only when a task needs it
+- Secrets: none required for review tasks by default
+
+## Notes
+
+- Codex cloud tasks automatically read `AGENTS.md` in this repo.
+- Setup scripts run in a separate shell session from the agent. Persistent env vars belong in Codex environment settings or `~/.bashrc`.
+- This repo uses required PR checks `test`, so cloud review tasks should preserve that contract.

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -1,0 +1,32 @@
+    # Bootstrap Onboarding
+
+    ## Repo Governance
+
+    - Confirm the repository exists at `OMT-Global/synology-github-runner`.
+    - Confirm branch protection or rulesets on `main` require one approval and code owner review.
+    - Confirm branch protection points at the `test` status.
+    - Confirm `delete branch on merge` and `allow auto-merge` are enabled.
+
+    ## Environments
+
+    - `dev`: open by default for rapid iteration.
+    - `stage`: one reviewer required and self-review blocked.
+    - `prod`: one reviewer required, self-review blocked, deployments limited to `main`.
+
+    ## Runner Policy
+
+    - Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
+    - Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
+    - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
+
+    ## Home Profiles
+
+    - Run `project-bootstrap apply home --manifest ./project.bootstrap.yaml` after reviewing the bundled profile content.
+    - The bootstrap manages portable Codex and Claude assets only. Auth, sessions, caches, and machine-local state stay unmanaged.
+
+    ## Claude Setup
+
+    - First-party Claude web sessions should use `bash scripts/claude-cloud/setup.sh` in `claude.ai/code`.
+- Interactive Claude work is prepared through `.devcontainer/devcontainer.json`.
+- GitHub-hosted Claude automation lives in `.github/workflows/claude.yml` and is intentionally separate from the required PR checks.
+- Finish GitHub-side auth by running `/install-github-app` in Claude Code or adding `ANTHROPIC_API_KEY` as a repo secret.

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -1,0 +1,87 @@
+version: 1
+project:
+  name: synology-github-runner
+  description: Shell-only GitHub self-hosted runner pools for Synology NAS deployments.
+  visibility: public
+  owner: OMT-Global
+  defaultBranch: main
+repo:
+  managedPaths:
+    - project.bootstrap.yaml
+    - AGENTS.md
+    - CLAUDE.md
+    - .devcontainer/**
+    - .github/workflows/claude.yml
+    - scripts/codex-cloud/**
+    - scripts/claude-cloud/**
+    - scripts/claude/**
+    - docs/bootstrap/**
+archetype:
+  kind: node-ts-service
+  packageManager: pnpm
+  moduleName: synology_github_runner
+github:
+  createRepo: false
+  reviewers:
+    - jmcte
+  codeowners:
+    - pattern: "*"
+      owners:
+        - "@jmcte"
+  autoMerge: true
+  deleteBranchOnMerge: true
+  requiredApprovals: 1
+  requiredStatusChecks:
+    - test
+  dismissStaleReviews: true
+  requireCodeOwnerReviews: true
+  requireLastPushApproval: false
+  enforceLinearHistory: true
+  allowMergeCommit: true
+  allowSquashMerge: true
+  allowRebaseMerge: false
+  repoFeatures:
+    hasIssues: true
+    hasProjects: false
+    hasWiki: false
+    hasDiscussions: false
+ci:
+  runnerPolicy: hybrid-safe
+  nodeVersion: 24.14.1
+  pythonVersion: "3.12"
+  fastChecks:
+    - lint
+    - test
+    - build
+  extendedChecks:
+    - smoke-test
+    - validate-image
+  nightlyCron: 0 7 * * *
+agents:
+  manageCodexHome: true
+  manageClaudeHome: true
+  codexProfile: default
+  claudeProfile: default
+  enableClaudeWebEnvironment: true
+  enableClaudeDevcontainer: true
+  enableClaudeGitHubAction: true
+  sharedSkills: []
+environments:
+  dev:
+    reviewers: []
+    requireApproval: false
+    preventSelfReview: false
+    branches: []
+  stage:
+    reviewers:
+      - jmcte
+    requireApproval: true
+    preventSelfReview: true
+    branches: []
+  prod:
+    reviewers:
+      - jmcte
+    requireApproval: true
+    preventSelfReview: true
+    branches:
+      - main

--- a/scripts/claude-cloud/setup.sh
+++ b/scripts/claude-cloud/setup.sh
@@ -1,0 +1,19 @@
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v gh >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y gh
+fi
+
+if [[ -f package-lock.json ]]; then
+  npm ci --prefer-offline --no-audit --no-fund
+elif [[ -f pnpm-lock.yaml ]]; then
+  corepack enable
+  pnpm install --frozen-lockfile
+elif [[ -f yarn.lock ]]; then
+  corepack enable
+  yarn install --immutable
+elif [[ -f package.json ]]; then
+  npm install --prefer-offline --no-audit --no-fund
+fi

--- a/scripts/claude/setup-devcontainer.sh
+++ b/scripts/claude/setup-devcontainer.sh
@@ -1,0 +1,16 @@
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    git config --global --add safe.directory "$(pwd)"
+
+if [[ -f package-lock.json ]]; then
+  npm ci --prefer-offline --no-audit --no-fund
+elif [[ -f pnpm-lock.yaml ]]; then
+  corepack enable
+  pnpm install --frozen-lockfile
+elif [[ -f yarn.lock ]]; then
+  corepack enable
+  yarn install --immutable
+elif [[ -f package.json ]]; then
+  npm install --prefer-offline --no-audit --no-fund
+fi

--- a/scripts/codex-cloud/maintenance.sh
+++ b/scripts/codex-cloud/maintenance.sh
@@ -1,0 +1,19 @@
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [[ -f package-lock.json ]]; then
+  npm ci --prefer-offline --no-audit --no-fund
+elif [[ -f pnpm-lock.yaml ]]; then
+  corepack enable
+  pnpm install --frozen-lockfile
+elif [[ -f yarn.lock ]]; then
+  corepack enable
+  yarn install --immutable
+elif [[ -f package.json ]]; then
+  npm install --prefer-offline --no-audit --no-fund
+fi
+
+if [[ -f pyproject.toml && -d .venv ]]; then
+  source .venv/bin/activate
+  python -m pip install -e ".[dev]" >/dev/null 2>&1 || python -m pip install -e . >/dev/null 2>&1 || true
+fi

--- a/scripts/codex-cloud/setup.sh
+++ b/scripts/codex-cloud/setup.sh
@@ -1,0 +1,14 @@
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [[ -f package-lock.json ]]; then
+  npm ci --prefer-offline --no-audit --no-fund
+elif [[ -f pnpm-lock.yaml ]]; then
+  corepack enable
+  pnpm install --frozen-lockfile
+elif [[ -f yarn.lock ]]; then
+  corepack enable
+  yarn install --immutable
+elif [[ -f package.json ]]; then
+  npm install --prefer-offline --no-audit --no-fund
+fi


### PR DESCRIPTION
## Summary
- add repo-local Codex and Claude bootstrap guidance and cloud setup scripts
- add Claude devcontainer and opt-in Claude GitHub workflow
- add a repo-specific project.bootstrap.yaml and onboarding docs without replacing existing CI, hooks, or README

## Testing
- pnpm lint
- pnpm test
- pnpm build