### PR TITLE
feat: add unified fleet doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,17 @@ pnpm install
 pnpm validate-config -- --config config/pools.yaml --env .env
 ```
 
-5. Validate that the configured GitHub runner groups already exist in the target organization:
+5. Run the unified fleet doctor before deployment changes:
+
+```bash
+pnpm doctor -- all --env .env --config config/pools.yaml --lume-config config/lume-runners.yaml
+pnpm doctor -- synology --env .env --config config/pools.yaml --format json
+pnpm doctor -- lume --env .env --lume-config config/lume-runners.yaml
+```
+
+`doctor` gives one operator-facing preflight for the whole fleet or for a targeted surface. It reuses the existing Synology and Lume validators, checks that the configured runner groups still exist, confirms the Synology image tag is present in GHCR, verifies shared GitHub API reachability, and emits either human-readable text or stable JSON for automation.
+
+6. Validate that the configured GitHub runner groups already exist in the target organization:
 
 ```bash
 pnpm validate-github -- --config config/pools.yaml --env .env
@@ -51,7 +61,7 @@ pnpm validate-github -- --config config/pools.yaml --env .env
 
 This catches mismatched or missing `runnerGroup` values before Synology starts containers that would otherwise enter a restart loop.
 
-6. Render the compose file:
+7. Render the compose file:
 
 ```bash
 pnpm render-compose -- --config config/pools.yaml --env .env --output docker-compose.generated.yml
@@ -61,7 +71,7 @@ The sample config uses `architecture: auto`, which lets Docker pull the native i
 
 If you set `resources.cpus` or `resources.pidsLimit`, `validate-config` and `render-compose` will warn because many Synology kernels reject Docker NanoCPUs, CPU CFS quotas, and PID cgroup limits. The sample config omits both limits for that reason.
 
-7. Build the runner image:
+8. Build the runner image:
 
 ```bash
 ./scripts/build-image.sh ghcr.io/your-org/synology-github-runner:0.1.9 --push
@@ -200,6 +210,9 @@ Keep the Lume runner env file outside git and locked down with `chmod 600`. The 
 ## Useful Commands
 
 ```bash
+pnpm doctor -- all --env .env --config config/pools.yaml --lume-config config/lume-runners.yaml
+pnpm doctor -- synology --env .env --config config/pools.yaml --format json
+pnpm doctor -- lume --env .env --lume-config config/lume-runners.yaml
 pnpm validate-config -- --config config/pools.yaml --env .env
 pnpm validate-github -- --config config/pools.yaml --env .env
 pnpm validate-image -- --config config/pools.yaml --env .env

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check-runner-version": "tsx src/cli.ts check-runner-version",
+    "doctor": "tsx src/cli.ts doctor",
     "install-synology-project": "tsx src/cli.ts install-synology-project",
     "lint": "tsc --noEmit -p tsconfig.json",
     "render-lume-runner-manifest": "tsx src/cli.ts render-lume-runner-manifest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
   verifyContainerImageTag,
   verifyRunnerGroups
 } from "./lib/github.js";
+import { formatDoctorText, runDoctor } from "./lib/doctor.js";
 import {
   buildRunnerDownloadUrl,
   summarizeRunnerVersion
@@ -52,6 +53,9 @@ async function main(): Promise<void> {
       break;
     case "runner-release-manifest":
       await runnerReleaseManifest(args);
+      break;
+    case "doctor":
+      await doctor(args);
       break;
     case "validate-lume-config":
       await validateLumeConfig(args);
@@ -319,6 +323,47 @@ async function runnerReleaseManifest(args: string[]): Promise<void> {
   );
 }
 
+async function doctor(args: string[]): Promise<void> {
+  const requestedMode = args[0] && !args[0]?.startsWith("--") ? args[0] : undefined;
+  const mode = (requestedMode ?? getOption(args, "--mode", "all")) as
+    | "synology"
+    | "lume"
+    | "all";
+  const format = getOption(args, "--format", "text");
+
+  if (!["synology", "lume", "all"].includes(mode)) {
+    throw new Error(`doctor mode must be one of synology, lume, or all; received ${mode}`);
+  }
+
+  if (!["text", "json"].includes(format!)) {
+    throw new Error(`doctor format must be text or json; received ${format}`);
+  }
+
+  const env = loadDeploymentEnv({
+    envPath: getOption(args, "--env", ".env"),
+    requirePat: false
+  });
+  const report = await runDoctor({
+    mode,
+    env,
+    synologyConfigPath: getOption(args, "--config", "config/pools.yaml"),
+    lumeConfigPath: getOption(args, "--lume-config", "config/lume-runners.yaml")
+  });
+
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    if (!report.ok) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  process.stdout.write(formatDoctorText(report));
+  if (!report.ok) {
+    process.exitCode = 1;
+  }
+}
+
 async function validateLumeConfig(args: string[]): Promise<void> {
   const env = loadDeploymentEnv({
     envPath: getOption(args, "--env", ".env"),
@@ -458,6 +503,7 @@ function printUsage(): void {
   pnpm teardown-synology-project [--config config/pools.yaml] [--env .env] [--dry-run] [--python python3]
   pnpm check-runner-version [--current 2.333.0] [--env .env]
   pnpm runner-release-manifest [--current 2.333.0] [--env .env]
+  pnpm doctor [synology|lume|all] [--env .env] [--config config/pools.yaml] [--lume-config config/lume-runners.yaml] [--format text|json]
   pnpm validate-lume-config [--config config/lume-runners.yaml] [--env .env]
   pnpm validate-lume-github [--config config/lume-runners.yaml] [--env .env]
   pnpm render-lume-runner-manifest [--config config/lume-runners.yaml] [--env .env] [--slot 1] [--format json|shell]

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -1,0 +1,291 @@
+import type { DeploymentEnv } from "./env.js";
+import { loadConfig } from "./config.js";
+import { loadLumeConfig } from "./lume-config.js";
+import {
+  fetchLatestRunnerRelease,
+  type FetchLike,
+  verifyContainerImageTag,
+  verifyRunnerGroups
+} from "./github.js";
+
+export type DoctorMode = "synology" | "lume" | "all";
+
+export interface DoctorOptions {
+  mode: DoctorMode;
+  env: DeploymentEnv;
+  synologyConfigPath?: string;
+  lumeConfigPath?: string;
+  fetchImpl?: FetchLike;
+}
+
+export interface DoctorCheck {
+  key: string;
+  ok: boolean;
+  summary: string;
+  detail?: unknown;
+}
+
+export interface DoctorSection {
+  key: "synology" | "lume" | "shared";
+  ok: boolean;
+  checks: DoctorCheck[];
+}
+
+export interface DoctorReport {
+  ok: boolean;
+  mode: DoctorMode;
+  sections: DoctorSection[];
+}
+
+export async function runDoctor(options: DoctorOptions): Promise<DoctorReport> {
+  const fetchImpl = options.fetchImpl;
+  const sections: DoctorSection[] = [];
+
+  if (options.mode === "synology" || options.mode === "all") {
+    sections.push(
+      await buildSynologySection(
+        options.env,
+        options.synologyConfigPath ?? "config/pools.yaml",
+        fetchImpl
+      )
+    );
+  }
+
+  if (options.mode === "lume" || options.mode === "all") {
+    sections.push(
+      await buildLumeSection(
+        options.env,
+        options.lumeConfigPath ?? "config/lume-runners.yaml",
+        fetchImpl
+      )
+    );
+  }
+
+  if (options.mode === "all") {
+    sections.unshift(await buildSharedSection(options.env, fetchImpl));
+  }
+
+  return {
+    ok: sections.every((section) => section.ok),
+    mode: options.mode,
+    sections
+  };
+}
+
+export function formatDoctorText(report: DoctorReport): string {
+  const lines = [`doctor mode=${report.mode} ok=${report.ok ? "true" : "false"}`];
+
+  for (const section of report.sections) {
+    lines.push(`${section.key}: ${section.ok ? "ok" : "failed"}`);
+    for (const check of section.checks) {
+      lines.push(`- [${check.ok ? "ok" : "fail"}] ${check.key}: ${check.summary}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function buildSharedSection(
+  env: DeploymentEnv,
+  fetchImpl?: FetchLike
+): Promise<DoctorSection> {
+  const checks: DoctorCheck[] = [];
+  const hasPat = Boolean(env.githubPat);
+  checks.push({
+    key: "github_pat",
+    ok: hasPat,
+    summary: hasPat ? "GITHUB_PAT is configured" : "GITHUB_PAT is missing"
+  });
+
+  if (hasPat) {
+    try {
+      const release = await fetchLatestRunnerRelease(
+        env.githubApiUrl,
+        env.githubPat,
+        fetchImpl
+      );
+      checks.push({
+        key: "runner_release",
+        ok: true,
+        summary: `latest actions/runner release is ${release.version}`,
+        detail: release
+      });
+    } catch (error) {
+      checks.push({
+        key: "runner_release",
+        ok: false,
+        summary: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  return finalizeSection("shared", checks);
+}
+
+async function buildSynologySection(
+  env: DeploymentEnv,
+  configPath: string,
+  fetchImpl?: FetchLike
+): Promise<DoctorSection> {
+  const checks: DoctorCheck[] = [];
+
+  try {
+    const config = loadConfig(configPath, env);
+    checks.push({
+      key: "config",
+      ok: true,
+      summary: `loaded ${config.pools.length} Synology pool(s)`
+    });
+
+    checks.push({
+      key: "synology_host",
+      ok: Boolean(env.synologyHost),
+      summary: env.synologyHost
+        ? `SYNOLOGY_HOST=${env.synologyHost}`
+        : "SYNOLOGY_HOST is missing"
+    });
+
+    if (!env.githubPat) {
+      checks.push({
+        key: "github_runner_groups",
+        ok: false,
+        summary: "GITHUB_PAT is required for GitHub runner group validation"
+      });
+      checks.push({
+        key: "image_tag",
+        ok: false,
+        summary: "GITHUB_PAT is required for GHCR image tag validation"
+      });
+      return finalizeSection("synology", checks);
+    }
+
+    try {
+      const groups = await verifyRunnerGroups(
+        env.githubApiUrl,
+        env.githubPat,
+        config.pools.map((pool) => ({
+          poolKey: pool.key,
+          organization: pool.organization,
+          runnerGroup: pool.runnerGroup
+        })),
+        fetchImpl
+      );
+      checks.push({
+        key: "github_runner_groups",
+        ok: true,
+        summary: `verified ${groups.length} Synology runner group mapping(s)`
+      });
+    } catch (error) {
+      checks.push({
+        key: "github_runner_groups",
+        ok: false,
+        summary: error instanceof Error ? error.message : String(error)
+      });
+    }
+
+    try {
+      const image = await verifyContainerImageTag(
+        env.githubApiUrl,
+        env.githubPat,
+        `${config.image.repository}:${config.image.tag}`,
+        fetchImpl
+      );
+      checks.push({
+        key: "image_tag",
+        ok: true,
+        summary: `verified image tag ${image.imageRef}`,
+        detail: image
+      });
+    } catch (error) {
+      checks.push({
+        key: "image_tag",
+        ok: false,
+        summary: error instanceof Error ? error.message : String(error)
+      });
+    }
+  } catch (error) {
+    checks.push({
+      key: "config",
+      ok: false,
+      summary: error instanceof Error ? error.message : String(error)
+    });
+  }
+
+  return finalizeSection("synology", checks);
+}
+
+async function buildLumeSection(
+  env: DeploymentEnv,
+  configPath: string,
+  fetchImpl?: FetchLike
+): Promise<DoctorSection> {
+  const checks: DoctorCheck[] = [];
+
+  try {
+    const config = loadLumeConfig(configPath, env);
+    checks.push({
+      key: "config",
+      ok: true,
+      summary: `loaded Lume pool ${config.pool.key} with ${config.pool.size} slot(s)`
+    });
+    checks.push({
+      key: "lume_env_file",
+      ok: true,
+      summary: `LUME_RUNNER_ENV_FILE=${env.lumeRunnerEnvFile}`
+    });
+
+    if (!env.githubPat) {
+      checks.push({
+        key: "github_runner_group",
+        ok: false,
+        summary: "GITHUB_PAT is required for GitHub runner group validation"
+      });
+      return finalizeSection("lume", checks);
+    }
+
+    try {
+      const groups = await verifyRunnerGroups(
+        env.githubApiUrl,
+        env.githubPat,
+        [
+          {
+            poolKey: config.pool.key,
+            organization: config.pool.organization,
+            runnerGroup: config.pool.runnerGroup
+          }
+        ],
+        fetchImpl
+      );
+      checks.push({
+        key: "github_runner_group",
+        ok: true,
+        summary: `verified Lume runner group ${groups[0]?.runnerGroup ?? config.pool.runnerGroup}`
+      });
+    } catch (error) {
+      checks.push({
+        key: "github_runner_group",
+        ok: false,
+        summary: error instanceof Error ? error.message : String(error)
+      });
+    }
+  } catch (error) {
+    checks.push({
+      key: "config",
+      ok: false,
+      summary: error instanceof Error ? error.message : String(error)
+    });
+  }
+
+  return finalizeSection("lume", checks);
+}
+
+function finalizeSection(
+  key: DoctorSection["key"],
+  checks: DoctorCheck[]
+): DoctorSection {
+  return {
+    key,
+    ok: checks.every((check) => check.ok),
+    checks
+  };
+}

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,0 +1,251 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { loadDeploymentEnv } from "../src/lib/env.js";
+import { formatDoctorText, runDoctor } from "../src/lib/doctor.js";
+import type { FetchLike } from "../src/lib/github.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("doctor", () => {
+  test("validates Synology mode with stable text and JSON-friendly results", async () => {
+    const fixture = createFixture({ withPat: true });
+    const report = await runDoctor({
+      mode: "synology",
+      env: fixture.env,
+      synologyConfigPath: fixture.synologyConfigPath,
+      lumeConfigPath: fixture.lumeConfigPath,
+      fetchImpl: buildFetchMock()
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.sections).toHaveLength(1);
+    expect(report.sections[0]).toMatchObject({
+      key: "synology",
+      ok: true
+    });
+    expect(formatDoctorText(report)).toContain("synology: ok");
+    expect(report.sections[0]?.checks.map((check) => check.key)).toEqual([
+      "config",
+      "synology_host",
+      "github_runner_groups",
+      "image_tag"
+    ]);
+  });
+
+  test("fails Synology mode clearly when GitHub credentials are missing", async () => {
+    const fixture = createFixture({ withPat: false });
+    const report = await runDoctor({
+      mode: "synology",
+      env: fixture.env,
+      synologyConfigPath: fixture.synologyConfigPath,
+      lumeConfigPath: fixture.lumeConfigPath
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.sections[0]?.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "github_runner_groups",
+          ok: false,
+          summary: expect.stringContaining("GITHUB_PAT is required")
+        }),
+        expect.objectContaining({
+          key: "image_tag",
+          ok: false,
+          summary: expect.stringContaining("GITHUB_PAT is required")
+        })
+      ])
+    );
+  });
+
+  test("validates Lume mode", async () => {
+    const fixture = createFixture({ withPat: true });
+    const report = await runDoctor({
+      mode: "lume",
+      env: fixture.env,
+      synologyConfigPath: fixture.synologyConfigPath,
+      lumeConfigPath: fixture.lumeConfigPath,
+      fetchImpl: buildFetchMock()
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.sections).toEqual([
+      expect.objectContaining({ key: "lume", ok: true })
+    ]);
+    expect(report.sections[0]?.checks.map((check) => check.key)).toEqual([
+      "config",
+      "lume_env_file",
+      "github_runner_group"
+    ]);
+  });
+
+  test("fails Lume mode clearly when GitHub credentials are missing", async () => {
+    const fixture = createFixture({ withPat: false });
+    const report = await runDoctor({
+      mode: "lume",
+      env: fixture.env,
+      synologyConfigPath: fixture.synologyConfigPath,
+      lumeConfigPath: fixture.lumeConfigPath
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.sections[0]?.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "github_runner_group",
+          ok: false,
+          summary: expect.stringContaining("GITHUB_PAT is required")
+        })
+      ])
+    );
+  });
+
+  test("runs the full fleet doctor mode", async () => {
+    const fixture = createFixture({ withPat: true });
+    const report = await runDoctor({
+      mode: "all",
+      env: fixture.env,
+      synologyConfigPath: fixture.synologyConfigPath,
+      lumeConfigPath: fixture.lumeConfigPath,
+      fetchImpl: buildFetchMock()
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.sections.map((section) => section.key)).toEqual([
+      "shared",
+      "synology",
+      "lume"
+    ]);
+    expect(report.sections[0]?.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "github_pat", ok: true }),
+        expect.objectContaining({ key: "runner_release", ok: true })
+      ])
+    );
+  });
+});
+
+function createFixture(options: { withPat: boolean }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "doctor-test-"));
+  tempDirs.push(dir);
+
+  const envPath = path.join(dir, ".env");
+  const synologyConfigPath = path.join(dir, "pools.yaml");
+  const lumeConfigPath = path.join(dir, "lume-runners.yaml");
+  const lumeBaseDir = path.join(dir, "lume");
+  const lumeEnvFile = path.join(lumeBaseDir, "runner.env");
+
+  fs.mkdirSync(lumeBaseDir, { recursive: true });
+  fs.writeFileSync(lumeEnvFile, "RUNNER_TOKEN=dummy\n", "utf8");
+  fs.writeFileSync(
+    envPath,
+    [
+      `GITHUB_API_URL=https://api.github.test`,
+      options.withPat ? `GITHUB_PAT=test-token` : "",
+      `SYNOLOGY_HOST=nas.example.test`,
+      `SYNOLOGY_USERNAME=admin`,
+      `SYNOLOGY_PASSWORD=secret`,
+      `SYNOLOGY_RUNNER_BASE_DIR=${path.join(dir, "synology-runners")}`,
+      `LUME_RUNNER_BASE_DIR=${lumeBaseDir}`,
+      `LUME_RUNNER_ENV_FILE=${lumeEnvFile}`
+    ]
+      .filter(Boolean)
+      .join("\n"),
+    "utf8"
+  );
+  fs.writeFileSync(
+    synologyConfigPath,
+    `version: 1
+image:
+  repository: ghcr.io/omt-global/github-runner-fleet
+  tag: 0.1.9
+pools:
+  - key: synology-private
+    visibility: private
+    organization: omt-global
+    runnerGroup: synology-private
+    repositoryAccess: selected
+    allowedRepositories:
+      - omt-global/example
+    labels: []
+    size: 2
+    architecture: auto
+    runnerRoot: ${JSON.stringify(path.join(dir, "synology-runners", "private"))}
+`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    lumeConfigPath,
+    `version: 1
+pool:
+  key: macos-private
+  organization: omt-global
+  runnerGroup: macos-private
+  size: 2
+  vmBaseName: macos-runner-base
+  vmSlotPrefix: macos-runner
+`,
+    "utf8"
+  );
+
+  return {
+    env: loadDeploymentEnv({ envPath, requirePat: false }),
+    synologyConfigPath,
+    lumeConfigPath
+  };
+}
+
+function buildFetchMock(): FetchLike {
+  return async (input) => {
+    if (input.endsWith("/repos/actions/runner/releases/latest")) {
+      return response(200, {
+        tag_name: "v2.333.0",
+        published_at: "2026-04-01T00:00:00Z",
+        html_url: "https://github.test/actions/runner/releases/v2.333.0"
+      });
+    }
+
+    if (input.includes("/actions/runner-groups")) {
+      if (input.includes("/orgs/omt-global/")) {
+        return response(200, {
+          runner_groups: [
+            { id: 1, name: "synology-private", visibility: "selected", default: false },
+            { id: 2, name: "macos-private", visibility: "selected", default: false }
+          ]
+        });
+      }
+    }
+
+    if (input.includes("/packages/container/github-runner-fleet/versions")) {
+      return response(200, [
+        {
+          id: 42,
+          updated_at: "2026-04-01T00:00:00Z",
+          metadata: {
+            container: {
+              tags: ["0.1.9"]
+            }
+          }
+        }
+      ]);
+    }
+
+    throw new Error(`unexpected fetch call: ${input}`);
+  };
+}
+
+function response(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body)
+  };
+}

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { loadDeploymentEnv } from "../src/lib/env.js";
 import { formatDoctorText, runDoctor } from "../src/lib/doctor.js";
 import type { FetchLike } from "../src/lib/github.js";
@@ -12,6 +12,7 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+  vi.unstubAllEnvs();
 });
 
 describe("doctor", () => {
@@ -41,6 +42,7 @@ describe("doctor", () => {
   });
 
   test("fails Synology mode clearly when GitHub credentials are missing", async () => {
+    vi.stubEnv("GITHUB_PAT", "");
     const fixture = createFixture({ withPat: false });
     const report = await runDoctor({
       mode: "synology",
@@ -88,6 +90,7 @@ describe("doctor", () => {
   });
 
   test("fails Lume mode clearly when GitHub credentials are missing", async () => {
+    vi.stubEnv("GITHUB_PAT", "");
     const fixture = createFixture({ withPat: false });
     const report = await runDoctor({
       mode: "lume",


### PR DESCRIPTION
## Summary
- add a unified `doctor` command for Synology, Lume, or full-fleet preflight checks
- emit stable JSON or human-readable text while reusing the existing config/GitHub/image validators
- cover doctor success and failure modes in tests and document the operator flow

## Testing
- corepack pnpm test
- corepack pnpm lint

Closes #26