### PR TITLE
feat: harden lume pool lifecycle workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,40 @@ pnpm validate-lume-github -- --config config/lume-runners.yaml --env .env
 pnpm render-lume-runner-manifest -- --config config/lume-runners.yaml --env .env --slot 1
 bash scripts/lume/create-base-vm.sh --config config/lume-runners.yaml --env .env
 bash scripts/lume/reconcile-pool.sh --config config/lume-runners.yaml --env .env
+bash scripts/lume/reconcile-pool.sh --config config/lume-runners.yaml --env .env --dry-run
+bash scripts/lume/reconcile-pool.sh --config config/lume-runners.yaml --env .env --once
 bash scripts/lume/status.sh --config config/lume-runners.yaml --env .env
+bash scripts/lume/status.sh --config config/lume-runners.yaml --env .env --format json
 ```
 
 Keep the Lume runner env file outside git and locked down with `chmod 600`. The host controller reads that file and copies it into each guest VM just before starting the guest bootstrap. Do not bake GitHub credentials into the base VM image.
+
+### Lume host layout and lifecycle playbook
+
+Treat the Lume host data as three separate layers:
+
+- base image state: the sealed base VM named by `vmBaseName`
+- host control-plane state: `LUME_RUNNER_BASE_DIR`, slot metadata under `slots/`, and logs under `logs/`
+- per-slot ephemeral state: cloned VMs named from `vmSlotPrefix`, transient guest bootstrap assets, and the copied runner env file
+
+A safe operator workflow looks like this:
+
+1. Validate the config and GitHub runner-group mapping.
+2. Create the base VM with `scripts/lume/create-base-vm.sh`.
+3. Boot the base VM manually, install Xcode and any pinned host-side prerequisites, verify the guest user can run CI workloads, then shut the VM down cleanly.
+4. Keep credentials out of the base image. Store them only in the host-side env file referenced by `LUME_RUNNER_ENV_FILE`.
+5. Run `scripts/lume/reconcile-pool.sh --dry-run` before starting or resizing the pool so you can see whether each slot will be created or have its worker restarted.
+6. Start the pool with `scripts/lume/reconcile-pool.sh`.
+7. Use `scripts/lume/status.sh --format json` for machine-readable status checks, and the default text output for quick terminal inspection.
+
+### Recovering and rotating Lume capacity
+
+- If one slot is unhealthy, stop its worker and recycle only that slot:
+  - inspect `logs/slot-XX.log` and `logs/slot-XX-vm.log`
+  - run `bash scripts/lume/destroy-slot.sh --slot <n> --config config/lume-runners.yaml --env .env`
+  - rerun `bash scripts/lume/reconcile-pool.sh --once --config config/lume-runners.yaml --env .env`
+- If the base image needs updates, shut down the pool, update and reseal the base VM, then rerun `reconcile-pool.sh` so fresh clones inherit the new image state.
+- `reconcile-pool.sh` now fails fast when the configured base VM is missing, which helps catch accidental host cleanup before the controller loops forever.
 
 ## Security Notes
 

--- a/scripts/lume/lib.sh
+++ b/scripts/lume/lib.sh
@@ -89,3 +89,7 @@ upload_env_file() {
 vm_exists() {
   lume get "${LUME_VM_NAME}" --format json $(storage_args) >/dev/null 2>&1
 }
+
+base_vm_exists() {
+  lume get "${LUME_VM_BASE_NAME}" --format json $(storage_args) >/dev/null 2>&1
+}

--- a/scripts/lume/reconcile-pool.sh
+++ b/scripts/lume/reconcile-pool.sh
@@ -6,6 +6,8 @@ source "${SCRIPT_DIR}/lib.sh"
 
 config_path="$(default_lume_config_path)"
 env_path="$(default_lume_env_path)"
+once=false
+dry_run=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -17,6 +19,14 @@ while [[ $# -gt 0 ]]; do
       env_path="$2"
       shift 2
       ;;
+    --once)
+      once=true
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
     *)
       echo "unknown argument: $1" >&2
       exit 1
@@ -25,22 +35,61 @@ while [[ $# -gt 0 ]]; do
 done
 
 pool_size="$(load_pool_size "${config_path}" "${env_path}")"
+load_slot_env "1" "${config_path}" "${env_path}"
+
+if ! base_vm_exists; then
+  echo "base VM ${LUME_VM_BASE_NAME} does not exist; create or rotate it before reconciling the pool" >&2
+  exit 1
+fi
+
 log "reconciling Lume runner pool with ${pool_size} slots"
 
-while true; do
+reconcile_once() {
+  local slot worker_running action
+
   for slot in $(seq 1 "${pool_size}"); do
     load_slot_env "${slot}" "${config_path}" "${env_path}"
     mkdir -p "${LUME_SLOT_DIR}" "$(dirname "${LUME_SLOT_LOG_FILE}")"
 
+    worker_running=false
     if [[ -f "${LUME_SLOT_WORKER_PID_FILE}" ]] && kill -0 "$(cat "${LUME_SLOT_WORKER_PID_FILE}")" >/dev/null 2>&1; then
+      worker_running=true
+    fi
+
+    if [[ "${worker_running}" == true ]]; then
+      action="healthy"
+    elif vm_exists; then
+      action="restart-worker"
+    else
+      action="create-slot"
+    fi
+
+    if [[ "${dry_run}" == true ]]; then
+      printf 'slot=%s vm=%s action=%s log=%s\n' \
+        "${slot}" \
+        "${LUME_VM_NAME}" \
+        "${action}" \
+        "${LUME_SLOT_LOG_FILE}"
       continue
     fi
 
-    log "starting slot worker ${slot} (${LUME_VM_NAME})"
+    if [[ "${action}" == "healthy" ]]; then
+      continue
+    fi
+
+    log "starting slot worker ${slot} (${LUME_VM_NAME}) action=${action}"
     nohup "${SCRIPT_DIR}/run-slot.sh" --slot "${slot}" --config "${config_path}" --env "${env_path}" \
       >> "${LUME_SLOT_LOG_FILE}" 2>&1 &
     echo $! > "${LUME_SLOT_WORKER_PID_FILE}"
   done
+}
+
+while true; do
+  reconcile_once
+
+  if [[ "${once}" == true || "${dry_run}" == true ]]; then
+    break
+  fi
 
   sleep 15
 done

--- a/scripts/lume/status.sh
+++ b/scripts/lume/status.sh
@@ -6,6 +6,7 @@ source "${SCRIPT_DIR}/lib.sh"
 
 config_path="$(default_lume_config_path)"
 env_path="$(default_lume_env_path)"
+format="text"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -17,6 +18,10 @@ while [[ $# -gt 0 ]]; do
       env_path="$2"
       shift 2
       ;;
+    --format)
+      format="$2"
+      shift 2
+      ;;
     *)
       echo "unknown argument: $1" >&2
       exit 1
@@ -24,7 +29,27 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ "${format}" != "text" && "${format}" != "json" ]]; then
+  echo "--format must be text or json" >&2
+  exit 1
+fi
+
 pool_size="$(load_pool_size "${config_path}" "${env_path}")"
+load_slot_env "1" "${config_path}" "${env_path}"
+base_vm_name="${LUME_VM_BASE_NAME}"
+base_vm_status="missing"
+if base_vm_exists; then
+  base_vm_status="present"
+fi
+
+if [[ "${format}" == "json" ]]; then
+  printf '{\n'
+  printf '  "poolSize": %s,\n' "${pool_size}"
+  printf '  "baseVm": {"name": "%s", "status": "%s"},\n' "${base_vm_name}" "${base_vm_status}"
+  printf '  "slots": [\n'
+else
+  printf 'base_vm=%s status=%s\n' "${base_vm_name}" "${base_vm_status}"
+fi
 
 for slot in $(seq 1 "${pool_size}"); do
   load_slot_env "${slot}" "${config_path}" "${env_path}"
@@ -39,6 +64,21 @@ for slot in $(seq 1 "${pool_size}"); do
     vm_status="present"
   fi
 
+  if [[ "${format}" == "json" ]]; then
+    printf '    {"slot": %s, "vmName": "%s", "worker": "%s", "vm": "%s", "log": "%s", "vmLog": "%s"}' \
+      "${slot}" \
+      "${LUME_VM_NAME}" \
+      "${worker_status}" \
+      "${vm_status}" \
+      "${LUME_SLOT_LOG_FILE}" \
+      "${LUME_SLOT_VM_LOG_FILE}"
+    if [[ "${slot}" != "${pool_size}" ]]; then
+      printf ','
+    fi
+    printf '\n'
+    continue
+  fi
+
   printf '%s worker=%s vm=%s log=%s vm_log=%s\n' \
     "${LUME_VM_NAME}" \
     "${worker_status}" \
@@ -46,3 +86,7 @@ for slot in $(seq 1 "${pool_size}"); do
     "${LUME_SLOT_LOG_FILE}" \
     "${LUME_SLOT_VM_LOG_FILE}"
 done
+
+if [[ "${format}" == "json" ]]; then
+  printf '  ]\n}\n'
+fi

--- a/test/lume-scripts.test.ts
+++ b/test/lume-scripts.test.ts
@@ -8,6 +8,7 @@ describe("Lume pool scripts", () => {
     const destroySlot = read("scripts/lume/destroy-slot.sh");
     const runSlot = read("scripts/lume/run-slot.sh");
     const reconcile = read("scripts/lume/reconcile-pool.sh");
+    const status = read("scripts/lume/status.sh");
 
     expect(createSlot).toContain('lume clone "${LUME_VM_BASE_NAME}" "${LUME_VM_NAME}"');
     expect(createSlot).toContain('lume set "${LUME_VM_NAME}" --cpu "${LUME_VM_CPU}"');
@@ -17,6 +18,16 @@ describe("Lume pool scripts", () => {
     expect(runSlot).toContain("uploading guest bootstrap assets");
     expect(runSlot).toContain('lume ssh "${LUME_VM_NAME}"');
     expect(reconcile).toContain('nohup "${SCRIPT_DIR}/run-slot.sh" --slot "${slot}"');
+    expect(reconcile).toContain('--dry-run');
+    expect(reconcile).toContain('--once');
+    expect(reconcile).toContain('base VM ${LUME_VM_BASE_NAME} does not exist');
+    expect(reconcile).toContain('action="create-slot"');
+    expect(reconcile).toContain('action="restart-worker"');
+    expect(reconcile).toContain('action="healthy"');
+    expect(destroySlot).toContain('rm -f "${LUME_SLOT_VM_PID_FILE}"');
+    expect(status).toContain('--format');
+    expect(status).toContain('"baseVm": {"name": "%s", "status": "%s"}');
+    expect(status).toContain('base_vm=%s status=%s');
   });
 
   test("bootstraps ephemeral macOS runners inside guest VMs", () => {


### PR DESCRIPTION
## Summary
- add clearer Lume lifecycle guards and operator surfaces for pool reconciliation and status
- document base VM rotation, host layout, and single-slot recovery workflow
- expand Lume script coverage for the new lifecycle/status contract

## Testing
- corepack pnpm test
- corepack pnpm lint
- bash -n scripts/lume/*.sh

Closes #27