### PR TITLE
feat: add synology deployment status surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ For a fully programmatic install from your workstation, this repo can also reuse
 
 ```bash
 pnpm render-synology-project-manifest -- --config config/pools.yaml --env .env
-pnpm install-synology-project -- --config config/pools.yaml --env .env
-pnpm teardown-synology-project -- --config config/pools.yaml --env .env
+pnpm install-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json
+pnpm teardown-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json
+pnpm synology-status -- --config config/pools.yaml --env .env --result .tmp/synology-status.json
 ```
 
 That installer path:
@@ -95,6 +96,29 @@ That installer path:
 `install-synology-project` is the recreate/resize path. If you change [config/pools.yaml](/Users/johnteneyckjr./src/synology-github-runner/config/pools.yaml) from four private runners to two, or from two public runners to six, rerun `pnpm install-synology-project ...` and the generated compose project will reconcile to the new slot counts. `--force-recreate` refreshes existing services, and `--remove-orphans` removes slots that no longer exist in the rendered compose file.
 
 Use `pnpm teardown-synology-project ...` when you want an explicit `docker compose down` on the NAS before reinstalling or when you want the runner project fully stopped.
+
+Use `pnpm synology-status ...` after an install or teardown attempt to inspect the saved DSM task result, the last known compose project state returned by `synology-api`, the expected remote log path, and the next troubleshooting steps. `install-synology-project` and `teardown-synology-project` now support `--status-output` so operators can persist the latest result for that command surface.
+
+### Synology operator runbook
+
+Recommended flow:
+
+1. `pnpm validate-config -- --config config/pools.yaml --env .env`
+2. `pnpm validate-github -- --config config/pools.yaml --env .env`
+3. `pnpm validate-image -- --config config/pools.yaml --env .env`
+4. `pnpm install-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json`
+5. `pnpm synology-status -- --config config/pools.yaml --env .env --result .tmp/synology-status.json`
+6. If recovery is needed, run `pnpm teardown-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json` and inspect status again before reinstalling.
+
+### Synology troubleshooting guide
+
+| Symptom | Next step |
+| --- | --- |
+| GitHub registration/auth failures | Run `pnpm validate-github -- --config config/pools.yaml --env .env` and confirm `GITHUB_PAT` plus runner groups are still valid. |
+| Image tag drift or pull failures | Run `pnpm validate-image -- --config config/pools.yaml --env .env` before reinstalling. |
+| Synology path permission failures | Inspect the remote `install-project.log` path reported by `pnpm synology-status` and verify `SYNOLOGY_PROJECT_DIR` plus runner state directories are writable. |
+| DSM task failure or timeout | Review the saved task result via `pnpm synology-status -- --result .tmp/synology-status.json`, then inspect the remote log path it prints. |
+| Need a clean rollback/recovery cycle | Run `pnpm teardown-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json`, confirm the saved result, then reinstall. |
 
 It intentionally avoids undocumented `SYNO.Docker.Project create/import` calls. If the Synology Docker daemon can see the compose project normally, Container Manager should still surface it as a compose project after the install task runs.
 
@@ -205,8 +229,9 @@ pnpm validate-github -- --config config/pools.yaml --env .env
 pnpm validate-image -- --config config/pools.yaml --env .env
 pnpm render-compose -- --config config/pools.yaml --env .env --output docker-compose.generated.yml
 pnpm render-synology-project-manifest -- --config config/pools.yaml --env .env
-pnpm install-synology-project -- --config config/pools.yaml --env .env
-pnpm teardown-synology-project -- --config config/pools.yaml --env .env
+pnpm install-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json
+pnpm teardown-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json
+pnpm synology-status -- --config config/pools.yaml --env .env --result .tmp/synology-status.json
 pnpm check-runner-version -- --env .env
 pnpm runner-release-manifest -- --env .env
 pnpm smoke-test

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "teardown-synology-project": "tsx src/cli.ts teardown-synology-project",
     "runner-release-manifest": "tsx src/cli.ts runner-release-manifest",
     "smoke-test": "bash scripts/smoke-test.sh",
+    "synology-status": "tsx src/cli.ts synology-status",
     "test": "vitest run",
     "validate-config": "tsx src/cli.ts validate-config",
     "validate-lume-config": "tsx src/cli.ts validate-lume-config",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,11 @@ import {
   buildSynologyInstallPlan,
   summarizeSynologyInstallPlan
 } from "./lib/synology-install.js";
+import {
+  buildSynologyStatusReport,
+  formatSynologyStatusText,
+  saveSynologyResult
+} from "./lib/synology-status.js";
 
 async function main(): Promise<void> {
   const [, , command, ...args] = process.argv;
@@ -46,6 +51,9 @@ async function main(): Promise<void> {
       break;
     case "teardown-synology-project":
       await teardownSynologyProject(args);
+      break;
+    case "synology-status":
+      await synologyStatus(args);
       break;
     case "check-runner-version":
       await checkRunnerVersion(args);
@@ -169,6 +177,7 @@ async function renderSynologyProjectManifest(args: string[]): Promise<void> {
 
 async function installSynologyProject(args: string[]): Promise<void> {
   const dryRun = args.includes("--dry-run");
+  const statusOutput = getOption(args, "--status-output", ".tmp/synology-status.json");
   const env = loadDeploymentEnv({
     envPath: getOption(args, "--env", ".env"),
     requirePat: !dryRun
@@ -203,11 +212,13 @@ async function installSynologyProject(args: string[]): Promise<void> {
     throw new Error(stderr || stdout || `installer exited with status ${result.status}`);
   }
 
+  saveSynologyResult(statusOutput!, "up", result.stdout);
   process.stdout.write(result.stdout);
 }
 
 async function teardownSynologyProject(args: string[]): Promise<void> {
   const dryRun = args.includes("--dry-run");
+  const statusOutput = getOption(args, "--status-output", ".tmp/synology-status.json");
   const env = loadDeploymentEnv({
     envPath: getOption(args, "--env", ".env"),
     requirePat: !dryRun
@@ -242,7 +253,40 @@ async function teardownSynologyProject(args: string[]): Promise<void> {
     throw new Error(stderr || stdout || `installer exited with status ${result.status}`);
   }
 
+  saveSynologyResult(statusOutput!, "down", result.stdout);
   process.stdout.write(result.stdout);
+}
+
+async function synologyStatus(args: string[]): Promise<void> {
+  const format = getOption(args, "--format", "text");
+  if (!["text", "json"].includes(format!)) {
+    throw new Error(`synology-status format must be text or json; received ${format}`);
+  }
+
+  const env = loadDeploymentEnv({
+    envPath: getOption(args, "--env", ".env"),
+    requirePat: false
+  });
+  const configPath = getOption(args, "--config", "config/pools.yaml");
+  const config = loadConfig(configPath!, env);
+  emitWarnings(config);
+  const compose = renderCompose(config, env);
+  const report = buildSynologyStatusReport({
+    config,
+    env,
+    composeContent: compose,
+    savedResultPath: getOption(args, "--result", ".tmp/synology-status.json")
+  });
+
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(formatSynologyStatusText(report));
+  }
+
+  if (!report.ok) {
+    process.exitCode = 1;
+  }
 }
 
 async function validateImage(args: string[]): Promise<void> {
@@ -454,8 +498,9 @@ function printUsage(): void {
   pnpm validate-image [--config config/pools.yaml] [--env .env]
   pnpm render-compose [--config config/pools.yaml] [--env .env] [--output docker-compose.generated.yml]
   pnpm render-synology-project-manifest [--config config/pools.yaml] [--env .env]
-  pnpm install-synology-project [--config config/pools.yaml] [--env .env] [--dry-run] [--python python3]
-  pnpm teardown-synology-project [--config config/pools.yaml] [--env .env] [--dry-run] [--python python3]
+  pnpm install-synology-project [--config config/pools.yaml] [--env .env] [--dry-run] [--python python3] [--status-output .tmp/synology-status.json]
+  pnpm teardown-synology-project [--config config/pools.yaml] [--env .env] [--dry-run] [--python python3] [--status-output .tmp/synology-status.json]
+  pnpm synology-status [--config config/pools.yaml] [--env .env] [--result .tmp/synology-status.json] [--format text|json]
   pnpm check-runner-version [--current 2.333.0] [--env .env]
   pnpm runner-release-manifest [--current 2.333.0] [--env .env]
   pnpm validate-lume-config [--config config/lume-runners.yaml] [--env .env]

--- a/src/lib/synology-status.ts
+++ b/src/lib/synology-status.ts
@@ -1,0 +1,273 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ResolvedConfig } from "./config.js";
+import type { DeploymentEnv } from "./env.js";
+import {
+  buildSynologyInstallPlan,
+  summarizeSynologyInstallPlan,
+  type SynologyInstallPlan,
+  type SynologyInstallSummary
+} from "./synology-install.js";
+
+export interface SynologySavedResult {
+  ok?: boolean;
+  project?: {
+    id?: number;
+    name?: string;
+    status?: string;
+    path?: string;
+    updated_at?: string;
+  } | null;
+  task?: {
+    id?: number;
+    result?: {
+      exit_code?: number | string;
+      start_time?: string;
+      end_time?: string;
+      extra?: unknown;
+      [key: string]: unknown;
+    };
+  };
+  remoteLogPath?: string;
+  options?: Record<string, unknown>;
+  recordedAt?: string;
+  action?: "up" | "down";
+}
+
+export interface SynologyStatusCheck {
+  key: string;
+  ok: boolean;
+  summary: string;
+}
+
+export interface SynologyTroubleshootingHint {
+  symptom: string;
+  nextStep: string;
+}
+
+export interface SynologyStatusReport {
+  ok: boolean;
+  summary: SynologyInstallSummary;
+  checks: SynologyStatusCheck[];
+  remoteLogPath: string;
+  savedResultPath?: string;
+  savedResult?: SynologySavedResult;
+  troubleshooting: SynologyTroubleshootingHint[];
+}
+
+export function buildSynologyStatusReport(options: {
+  config: ResolvedConfig;
+  env: DeploymentEnv;
+  composeContent: string;
+  savedResultPath?: string;
+}): SynologyStatusReport {
+  const plan = buildSynologyInstallPlan(options.config, options.env, options.composeContent, {
+    allowIncomplete: true,
+    action: "up"
+  });
+  const summary = summarizeSynologyInstallPlan(plan);
+  const remoteLogPath = path.posix.join(
+    plan.project.directory,
+    "logs",
+    plan.project.logFileName
+  );
+  const resolvedSavedResultPath = options.savedResultPath
+    ? path.resolve(options.savedResultPath)
+    : undefined;
+  const checks = buildChecks(plan, resolvedSavedResultPath);
+  const savedResult = resolvedSavedResultPath
+    ? loadSavedResult(resolvedSavedResultPath)
+    : undefined;
+
+  if (savedResult && resolvedSavedResultPath) {
+    checks.push(...buildSavedResultChecks(savedResult, resolvedSavedResultPath));
+  } else if (resolvedSavedResultPath) {
+    checks.push({
+      key: "saved_result",
+      ok: false,
+      summary: `no saved Synology result found at ${resolvedSavedResultPath}`
+    });
+  }
+
+  return {
+    ok: checks.every((check) => check.ok),
+    summary,
+    checks,
+    remoteLogPath,
+    savedResultPath: resolvedSavedResultPath,
+    savedResult,
+    troubleshooting: buildTroubleshooting(plan, savedResult, remoteLogPath)
+  };
+}
+
+export function formatSynologyStatusText(report: SynologyStatusReport): string {
+  const lines = [
+    `synology-status ok=${report.ok ? "true" : "false"}`,
+    `project=${report.summary.project.name} host=${report.summary.connection.host || "<missing>"}`,
+    `remote_log=${report.remoteLogPath}`
+  ];
+
+  for (const check of report.checks) {
+    lines.push(`- [${check.ok ? "ok" : "fail"}] ${check.key}: ${check.summary}`);
+  }
+
+  if (report.savedResult?.task?.result) {
+    const result = report.savedResult.task.result;
+    lines.push(
+      `recent_task exit_code=${String(result.exit_code ?? "unknown")} start=${String(result.start_time ?? "unknown")} end=${String(result.end_time ?? "unknown")}`
+    );
+  }
+
+  if (report.savedResult?.project) {
+    lines.push(
+      `recent_project status=${String(report.savedResult.project.status ?? "unknown")} updated_at=${String(report.savedResult.project.updated_at ?? "unknown")}`
+    );
+  }
+
+  lines.push("troubleshooting:");
+  for (const hint of report.troubleshooting) {
+    lines.push(`- ${hint.symptom}: ${hint.nextStep}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function saveSynologyResult(
+  outputPath: string,
+  action: "up" | "down",
+  rawOutput: string
+): SynologySavedResult {
+  const parsed = JSON.parse(rawOutput) as SynologySavedResult;
+  const record: SynologySavedResult = {
+    ...parsed,
+    action,
+    recordedAt: new Date().toISOString()
+  };
+  fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+  fs.writeFileSync(path.resolve(outputPath), `${JSON.stringify(record, null, 2)}\n`, "utf8");
+  return record;
+}
+
+function loadSavedResult(savedResultPath: string): SynologySavedResult | undefined {
+  const resolved = path.resolve(savedResultPath);
+  if (!fs.existsSync(resolved)) {
+    return undefined;
+  }
+  return JSON.parse(fs.readFileSync(resolved, "utf8")) as SynologySavedResult;
+}
+
+function buildChecks(
+  plan: SynologyInstallPlan,
+  savedResultPath?: string
+): SynologyStatusCheck[] {
+  const connection = plan.connection;
+  return [
+    {
+      key: "synology_env",
+      ok: Boolean(connection.host && connection.username && connection.password),
+      summary:
+        connection.host && connection.username && connection.password
+          ? `Synology host ${connection.host}:${connection.port} credentials are configured`
+          : "SYNOLOGY_HOST, SYNOLOGY_USERNAME, or SYNOLOGY_PASSWORD is missing"
+    },
+    {
+      key: "github_pat",
+      ok: connection.password.length > 0 || plan.envFileContent.includes("GITHUB_PAT=\"") === false,
+      summary: plan.envFileContent.includes('GITHUB_PAT=""')
+        ? "GITHUB_PAT is missing from the deployment env"
+        : "GITHUB_PAT is configured for remote runner registration"
+    },
+    {
+      key: "synology_api_repo",
+      ok: fs.existsSync(connection.apiRepo),
+      summary: fs.existsSync(connection.apiRepo)
+        ? `synology-api repo found at ${connection.apiRepo}`
+        : `synology-api repo not found at ${connection.apiRepo}`
+    },
+    {
+      key: "compose_project",
+      ok: true,
+      summary: `project ${plan.project.name} will deploy under ${plan.project.directory}`
+    },
+    {
+      key: "saved_result_path",
+      ok: savedResultPath ? fs.existsSync(path.resolve(savedResultPath)) : true,
+      summary: savedResultPath
+        ? fs.existsSync(path.resolve(savedResultPath))
+          ? `saved result found at ${path.resolve(savedResultPath)}`
+          : `save install output with --status-output or provide --result ${path.resolve(savedResultPath)}`
+        : "use --result or --status-output to inspect the latest saved install result"
+    }
+  ];
+}
+
+function buildSavedResultChecks(
+  savedResult: SynologySavedResult,
+  savedResultPath: string
+): SynologyStatusCheck[] {
+  const checks: SynologyStatusCheck[] = [
+    {
+      key: "saved_result",
+      ok: true,
+      summary: `loaded saved Synology result from ${path.resolve(savedResultPath)}`
+    }
+  ];
+
+  if (savedResult.task?.result) {
+    const exitCode = Number(savedResult.task.result.exit_code ?? 1);
+    checks.push({
+      key: "recent_task",
+      ok: exitCode === 0,
+      summary: `recent DSM task exit_code=${savedResult.task.result.exit_code ?? "unknown"}`
+    });
+  }
+
+  if (savedResult.project) {
+    const projectStatus = String(savedResult.project.status ?? "unknown");
+    checks.push({
+      key: "recent_project",
+      ok: projectStatus !== "error",
+      summary: `recent compose project status=${projectStatus}`
+    });
+  }
+
+  return checks;
+}
+
+function buildTroubleshooting(
+  plan: SynologyInstallPlan,
+  savedResult: SynologySavedResult | undefined,
+  remoteLogPath: string
+): SynologyTroubleshootingHint[] {
+  const hints: SynologyTroubleshootingHint[] = [
+    {
+      symptom: "GitHub auth or registration failures",
+      nextStep: "Run `pnpm validate-github -- --config config/pools.yaml --env .env` and confirm GITHUB_PAT plus runner groups are still valid."
+    },
+    {
+      symptom: "Image tag drift or missing image",
+      nextStep: "Run `pnpm validate-image -- --config config/pools.yaml --env .env` before reinstalling so the NAS does not pull a nonexistent GHCR tag."
+    },
+    {
+      symptom: "Synology path permission or bind-mount failures",
+      nextStep: `Inspect ${remoteLogPath} and verify ${plan.project.directory} plus all runner state directories are writable on the NAS.`
+    },
+    {
+      symptom: "Task execution failed or timed out",
+      nextStep: `Review the DSM Task Scheduler result and the remote log at ${remoteLogPath}, then rerun \`pnpm install-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json\`.`
+    },
+    {
+      symptom: "Need a clean teardown or recovery cycle",
+      nextStep: "Run `pnpm teardown-synology-project -- --config config/pools.yaml --env .env --status-output .tmp/synology-status.json`, confirm the saved result, then reinstall."
+    }
+  ];
+
+  if (savedResult?.task?.result && Number(savedResult.task.result.exit_code ?? 1) !== 0) {
+    hints.unshift({
+      symptom: "Latest saved install attempt failed",
+      nextStep: `Start with ${remoteLogPath} and the saved task exit code ${String(savedResult.task.result.exit_code)}.`
+    });
+  }
+
+  return hints;
+}

--- a/src/lib/synology-status.ts
+++ b/src/lib/synology-status.ts
@@ -161,6 +161,7 @@ function buildChecks(
   savedResultPath?: string
 ): SynologyStatusCheck[] {
   const connection = plan.connection;
+  const githubPatConfigured = !plan.envFileContent.includes('GITHUB_PAT=""');
   return [
     {
       key: "synology_env",
@@ -172,10 +173,10 @@ function buildChecks(
     },
     {
       key: "github_pat",
-      ok: connection.password.length > 0 || plan.envFileContent.includes("GITHUB_PAT=\"") === false,
-      summary: plan.envFileContent.includes('GITHUB_PAT=""')
-        ? "GITHUB_PAT is missing from the deployment env"
-        : "GITHUB_PAT is configured for remote runner registration"
+      ok: githubPatConfigured,
+      summary: githubPatConfigured
+        ? "GITHUB_PAT is configured for remote runner registration"
+        : "GITHUB_PAT is missing from the deployment env"
     },
     {
       key: "synology_api_repo",

--- a/test/synology-status.test.ts
+++ b/test/synology-status.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { renderCompose } from "../src/lib/compose.js";
+import type { ResolvedConfig } from "../src/lib/config.js";
+import type { DeploymentEnv } from "../src/lib/env.js";
+import {
+  buildSynologyStatusReport,
+  formatSynologyStatusText,
+  saveSynologyResult
+} from "../src/lib/synology-status.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("synology status", () => {
+  test("summarizes saved install status and troubleshooting surfaces", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "synology-status-"));
+    tempDirs.push(dir);
+    const apiRepo = path.join(dir, "synology-api");
+    fs.mkdirSync(apiRepo, { recursive: true });
+    const resultPath = path.join(dir, "status.json");
+
+    saveSynologyResult(
+      resultPath,
+      "up",
+      JSON.stringify({
+        ok: true,
+        project: {
+          name: "synology-github-runner",
+          status: "running",
+          updated_at: "2026-04-12T08:00:00Z"
+        },
+        task: {
+          id: 77,
+          result: {
+            exit_code: 0,
+            start_time: "2026-04-12T07:59:00Z",
+            end_time: "2026-04-12T08:00:00Z"
+          }
+        },
+        remoteLogPath: "/volume1/docker/synology-github-runner/logs/install-project.log"
+      })
+    );
+
+    const env = envFixture(apiRepo);
+    const report = buildSynologyStatusReport({
+      config: configFixture(),
+      env,
+      composeContent: renderCompose(configFixture(), env),
+      savedResultPath: resultPath
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.savedResult?.task?.result?.exit_code).toBe(0);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "saved_result", ok: true }),
+        expect.objectContaining({ key: "recent_task", ok: true }),
+        expect.objectContaining({ key: "recent_project", ok: true })
+      ])
+    );
+    expect(formatSynologyStatusText(report)).toContain("recent_task exit_code=0");
+    expect(formatSynologyStatusText(report)).toContain("troubleshooting:");
+  });
+
+  test("reports missing prerequisites and missing saved result clearly", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "synology-status-missing-"));
+    tempDirs.push(dir);
+    const missingResult = path.join(dir, "missing.json");
+    const env = envFixture(path.join(dir, "missing-api"));
+    env.githubPat = undefined;
+    env.synologyHost = undefined;
+    env.synologyUsername = undefined;
+    env.synologyPassword = undefined;
+
+    const report = buildSynologyStatusReport({
+      config: configFixture(),
+      env,
+      composeContent: renderCompose(configFixture(), env),
+      savedResultPath: missingResult
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "synology_env", ok: false }),
+        expect.objectContaining({ key: "github_pat", ok: false }),
+        expect.objectContaining({ key: "synology_api_repo", ok: false }),
+        expect.objectContaining({ key: "saved_result_path", ok: false })
+      ])
+    );
+  });
+});
+
+function configFixture(): ResolvedConfig {
+  return {
+    version: 1,
+    image: {
+      repository: "ghcr.io/example/synology-github-runner",
+      tag: "0.1.9"
+    },
+    pools: [
+      {
+        key: "synology-private",
+        visibility: "private",
+        organization: "example",
+        runnerGroup: "synology-private",
+        repositoryAccess: "all",
+        allowedRepositories: [],
+        labels: ["synology", "shell-only", "private"],
+        size: 1,
+        architecture: "auto",
+        runnerRoot: "/volume1/docker/synology-github-runner/pools/synology-private",
+        resources: {
+          memory: "2g"
+        },
+        imageRef: "ghcr.io/example/synology-github-runner:0.1.9"
+      }
+    ]
+  };
+}
+
+function envFixture(apiRepo: string): DeploymentEnv {
+  return {
+    githubPat: "test-pat",
+    githubApiUrl: "https://api.github.com",
+    synologyRunnerBaseDir: "/volume1/docker/synology-github-runner",
+    synologyHost: "nas.example.com",
+    synologyPort: "5001",
+    synologyUsername: "admin",
+    synologyPassword: "secret",
+    synologySecure: true,
+    synologyCertVerify: false,
+    synologyDsmVersion: 7,
+    synologyApiRepo: apiRepo,
+    synologyProjectDir: "/volume1/docker/synology-github-runner",
+    synologyProjectComposeFile: "compose.yaml",
+    synologyProjectEnvFile: ".env",
+    synologyInstallPullImages: true,
+    synologyInstallForceRecreate: true,
+    synologyInstallRemoveOrphans: true,
+    lumeRunnerBaseDir:
+      "/Users/tester/Library/Application Support/synology-github-runner/lume",
+    lumeRunnerEnvFile:
+      "/Users/tester/Library/Application Support/synology-github-runner/lume/runner.env",
+    composeProjectName: "synology-github-runner",
+    runnerVersion: "2.333.0",
+    raw: {}
+  };
+}

--- a/test/synology-status.test.ts
+++ b/test/synology-status.test.ts
@@ -97,6 +97,36 @@ describe("synology status", () => {
       ])
     );
   });
+
+  test("fails github_pat when GitHub auth is missing but Synology auth is configured", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "synology-status-github-pat-"));
+    tempDirs.push(dir);
+    const apiRepo = path.join(dir, "synology-api");
+    fs.mkdirSync(apiRepo, { recursive: true });
+    const env = envFixture(apiRepo);
+    env.githubPat = undefined;
+
+    const report = buildSynologyStatusReport({
+      config: configFixture(),
+      env,
+      composeContent: renderCompose(configFixture(), env)
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "synology_env",
+          ok: true
+        }),
+        expect.objectContaining({
+          key: "github_pat",
+          ok: false,
+          summary: "GITHUB_PAT is missing from the deployment env"
+        })
+      ])
+    );
+  });
 });
 
 function configFixture(): ResolvedConfig {


### PR DESCRIPTION
## Summary
- add a `synology-status` command that summarizes saved deployment results, expected remote logs, and next troubleshooting steps
- persist install and teardown results via `--status-output` so operators can inspect the latest DSM task and compose project state
- document the Synology operator runbook and troubleshooting flow, and cover the new status surface in tests

## Testing
- corepack pnpm test
- corepack pnpm lint

Closes #29