### PR TITLE
fix: address issue #50

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "4.1.4",
+    "fast-check": "^4.7.0",
     "tsx": "^4.20.6",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.4
         version: 4.1.4(vitest@4.1.4)
+      fast-check:
+        specifier: ^4.7.0
+        version: 4.7.0
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
@@ -1020,6 +1023,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-check@4.7.0:
+    resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1256,6 +1263,9 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -2417,6 +2427,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-check@4.7.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-string-truncated-width@3.0.3: {}
@@ -2608,6 +2622,8 @@ snapshots:
       parse-ms: 4.0.0
 
   progress@2.0.3: {}
+
+  pure-rand@8.4.0: {}
 
   qs@6.15.1:
     dependencies:

--- a/test/config.property.test.ts
+++ b/test/config.property.test.ts
@@ -1,0 +1,286 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import fc from "fast-check";
+import YAML from "yaml";
+import { afterEach, describe, expect, test } from "vitest";
+import { loadConfig } from "../src/lib/config.js";
+import type { DeploymentEnv } from "../src/lib/env.js";
+
+const propertyOptions = { numRuns: 40 };
+const tempPaths: string[] = [];
+
+afterEach(() => {
+  for (const tempPath of tempPaths.splice(0)) {
+    fs.rmSync(tempPath, { recursive: true, force: true });
+  }
+});
+
+describe("loadConfig property validation", () => {
+  test("rejects pool sizes below one", () => {
+    fc.assert(
+      fc.property(fc.integer({ max: 0 }), (size) => {
+        expect(() => loadPoolConfig({ size })).toThrow();
+      }),
+      propertyOptions
+    );
+  });
+
+  test("rejects non-integer pool sizes", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 100 }), (size) => {
+        expect(() => loadPoolConfig({ size: size + 0.5 })).toThrow();
+      }),
+      propertyOptions
+    );
+  });
+
+  test("rejects pool keys containing control characters", () => {
+    fc.assert(
+      fc.property(fc.constantFrom("\0", "\n", "\r", "\t"), (badChar) => {
+        expect(() => loadPoolConfig({ key: `pool${badChar}name` })).toThrow();
+      }),
+      propertyOptions
+    );
+  });
+
+  test("rejects labels outside the shell-safe label pattern", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("", "bad label", "bad/label", "bad:label", "snowman-☃"),
+        (label) => {
+          expect(() => loadPoolConfig({ labels: ["shell-safe", label] })).toThrow();
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("keeps generated shell-safe labels and injects required labels once", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.stringMatching(/^[A-Za-z0-9._-]{1,16}$/), {
+          maxLength: 8
+        }),
+        (labels) => {
+          const config = loadPoolConfig({
+            visibility: "public",
+            labels: ["synology", "shell-only", "public", ...labels]
+          });
+
+          expect(config.pools[0].labels).toEqual([
+            ...new Set(["synology", "shell-only", "public", ...labels])
+          ]);
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("rejects malformed selected repository names", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("", "repo", "example/", "/repo", "example/repo/extra", "bad owner/repo"),
+        (repository) => {
+          expect(() =>
+            loadPoolConfig({
+              repositoryAccess: "selected",
+              allowedRepositories: [repository]
+            })
+          ).toThrow();
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("rejects selected repository access without repositories", () => {
+    fc.assert(
+      fc.property(fc.constant("selected" as const), (repositoryAccess) => {
+        expect(() =>
+          loadPoolConfig({ repositoryAccess, allowedRepositories: [] })
+        ).toThrow(/allowedRepositories must contain at least one repository/);
+      }),
+      propertyOptions
+    );
+  });
+
+  test("rejects allow-lists when repository access is all", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.stringMatching(/^example\/[A-Za-z0-9_.-]{1,16}$/), {
+          minLength: 1,
+          maxLength: 5
+        }),
+        (allowedRepositories) => {
+          expect(() =>
+            loadPoolConfig({
+              repositoryAccess: "all",
+              allowedRepositories
+            })
+          ).toThrow(/allowedRepositories must be omitted/);
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("rejects selected repositories outside the pool organization", () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[A-Za-z0-9_.-]{1,16}$/),
+        fc.stringMatching(/^[A-Za-z0-9_.-]{1,16}$/),
+        (owner, repo) => {
+          fc.pre(owner !== "example");
+
+          expect(() =>
+            loadPoolConfig({
+              repositoryAccess: "selected",
+              allowedRepositories: [`${owner}/${repo}`]
+            })
+          ).toThrow(/outside organization example/);
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("rejects malformed CPU resource strings", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("", "abc", "-1", "1.", ".5", "1m", "1/2"),
+        (cpus) => {
+          expect(() =>
+            loadPoolConfig({
+              resources: {
+                cpus
+              }
+            })
+          ).toThrow();
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("rejects non-positive PID limits", () => {
+    fc.assert(
+      fc.property(fc.integer({ max: 0 }), (pidsLimit) => {
+        expect(() =>
+          loadPoolConfig({
+            resources: {
+              pidsLimit
+            }
+          })
+        ).toThrow();
+      }),
+      propertyOptions
+    );
+  });
+
+  test("accepts arbitrary non-empty memory strings", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 32 }).filter((value) => !value.includes("\0")),
+        (memory) => {
+          const config = loadPoolConfig({
+            resources: {
+              memory
+            }
+          });
+
+          expect(config.pools[0].resources.memory).toBe(memory);
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("uses default interpolation values containing malformed placeholder text", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("${", "${NAME", "${NAME:", "${NAME:-", "${name}", "${NAME-default}"),
+        (defaultValue) => {
+          const config = loadPoolConfig({
+            runnerRoot: `/runners/${"${MISSING:-" + defaultValue + "}"}`
+          });
+
+          expect(config.pools[0].runnerRoot).toBe(`/runners/${defaultValue}`);
+        }
+      ),
+      propertyOptions
+    );
+  });
+});
+
+function loadPoolConfig(poolOverrides: Record<string, unknown>) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "config-property-"));
+  tempPaths.push(directory);
+  const configPath = path.join(directory, "pools.yaml");
+  const pool = {
+    key: "synology-private",
+    visibility: "private",
+    organization: "example",
+    runnerGroup: "synology-private",
+    repositoryAccess: "selected",
+    allowedRepositories: ["example/private-app"],
+    labels: [],
+    size: 1,
+    architecture: "arm64",
+    runnerRoot: "/volume1/docker/github-runner-fleet/pools/synology-private",
+    ...poolOverrides
+  };
+
+  fs.writeFileSync(
+    configPath,
+    YAML.stringify({
+      version: 1,
+      image: {
+        repository: "ghcr.io/example/github-runner-fleet",
+        tag: "0.1.5"
+      },
+      pools: [pool]
+    }),
+    "utf8"
+  );
+
+  return loadConfig(configPath, deploymentEnv());
+}
+
+function deploymentEnv(): DeploymentEnv {
+  return {
+    githubApiUrl: "https://api.github.com",
+    synologyRunnerBaseDir: "/volume1/docker/github-runner-fleet",
+    synologyHost: "nas.example.com",
+    synologyPort: "5001",
+    synologyUsername: "admin",
+    synologyPassword: "secret",
+    synologySecure: true,
+    synologyCertVerify: false,
+    synologyDsmVersion: 7,
+    synologyApiRepo: "/Users/tester/src/synology-api",
+    synologyProjectDir: "/volume1/docker/github-runner-fleet",
+    synologyProjectComposeFile: "compose.yaml",
+    synologyProjectEnvFile: ".env",
+    synologyInstallPullImages: true,
+    synologyInstallForceRecreate: true,
+    synologyInstallRemoveOrphans: true,
+    linuxDockerRunnerBaseDir: "/srv/github-runner-fleet/linux-docker",
+    linuxDockerHost: "docker-host.example.com",
+    linuxDockerPort: "22",
+    linuxDockerUsername: "runner",
+    linuxDockerProjectDir: "/srv/github-runner-fleet/linux-docker",
+    linuxDockerProjectComposeFile: "compose.yaml",
+    linuxDockerProjectEnvFile: ".env",
+    linuxDockerInstallPullImages: true,
+    linuxDockerInstallForceRecreate: true,
+    linuxDockerInstallRemoveOrphans: true,
+    lumeRunnerBaseDir:
+      "/Users/tester/Library/Application Support/github-runner-fleet/lume",
+    lumeRunnerEnvFile:
+      "/Users/tester/Library/Application Support/github-runner-fleet/lume/runner.env",
+    composeProjectName: "github-runner-fleet",
+    runnerVersion: "2.327.1",
+    raw: {}
+  };
+}

--- a/test/env.property.test.ts
+++ b/test/env.property.test.ts
@@ -1,0 +1,196 @@
+import os from "node:os";
+import path from "node:path";
+import fc from "fast-check";
+import { describe, expect, test } from "vitest";
+import { loadDeploymentEnv } from "../src/lib/env.js";
+
+const propertyOptions = { numRuns: 40 };
+const booleanKeys = [
+  "SYNOLOGY_SECURE",
+  "SYNOLOGY_CERT_VERIFY",
+  "SYNOLOGY_INSTALL_PULL_IMAGES",
+  "SYNOLOGY_INSTALL_FORCE_RECREATE",
+  "SYNOLOGY_INSTALL_REMOVE_ORPHANS",
+  "LINUX_DOCKER_INSTALL_PULL_IMAGES",
+  "LINUX_DOCKER_INSTALL_FORCE_RECREATE",
+  "LINUX_DOCKER_INSTALL_REMOVE_ORPHANS"
+];
+const truthyValues = ["1", "true", "TRUE", " yes ", "On"];
+const falseyValues = ["0", "false", "FALSE", " no ", "Off"];
+
+describe("loadDeploymentEnv property validation", () => {
+  test("accepts supported truthy boolean spellings", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...truthyValues), (value) => {
+        const env = withEnv({ SYNOLOGY_SECURE: value }, () =>
+          loadDeploymentEnv({
+            envPath: "/nonexistent/.env",
+            requirePat: false
+          })
+        );
+
+        expect(env.synologySecure).toBe(true);
+        expect(env.raw.SYNOLOGY_SECURE).toBe("true");
+      }),
+      propertyOptions
+    );
+  });
+
+  test("accepts supported falsey boolean spellings", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...falseyValues), (value) => {
+        const env = withEnv(
+          {
+            SYNOLOGY_SECURE: value,
+            SYNOLOGY_PORT: undefined
+          },
+          () =>
+            loadDeploymentEnv({
+              envPath: "/nonexistent/.env",
+              requirePat: false
+            })
+        );
+
+        expect(env.synologySecure).toBe(false);
+        expect(env.synologyPort).toBe("5000");
+        expect(env.raw.SYNOLOGY_SECURE).toBe("false");
+      }),
+      propertyOptions
+    );
+  });
+
+  test("rejects arbitrary unsupported boolean values for every boolean option", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...booleanKeys),
+        fc
+          .string({ minLength: 1, maxLength: 24 })
+          .filter((value) => !isSupportedBoolean(value) && !value.includes("\0")),
+        (key, value) => {
+          expect(() =>
+            withEnv({ [key]: value }, () =>
+              loadDeploymentEnv({
+                envPath: "/nonexistent/.env",
+                requirePat: false
+              })
+            )
+          ).toThrow(/invalid boolean value/);
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("strips any run of trailing slashes from the GitHub API URL", () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[A-Za-z0-9._~-]{1,24}$/),
+        fc.integer({ min: 1, max: 8 }),
+        (segment, slashCount) => {
+          const baseUrl = `https://ghe.example.com/api/${segment}`;
+          const env = withEnv(
+            {
+              GITHUB_API_URL: `${baseUrl}${"/".repeat(slashCount)}`
+            },
+            () =>
+              loadDeploymentEnv({
+                envPath: "/nonexistent/.env",
+                requirePat: false
+              })
+          );
+
+          expect(env.githubApiUrl).toBe(baseUrl);
+          expect(env.raw.GITHUB_API_URL).toBe(baseUrl);
+        }
+      ),
+      propertyOptions
+    );
+  });
+
+  test("expands home-relative Linux runner base directories", () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[A-Za-z0-9._-]{1,24}$/), (segment) => {
+        const env = withEnv(
+          {
+            LINUX_DOCKER_RUNNER_BASE_DIR: `~/${segment}`
+          },
+          () =>
+            loadDeploymentEnv({
+              envPath: "/nonexistent/.env",
+              requirePat: false
+            })
+        );
+
+        expect(env.linuxDockerRunnerBaseDir).toBe(pathFromHome(segment));
+        expect(env.linuxDockerProjectDir).toBe(pathFromHome(segment));
+      }),
+      propertyOptions
+    );
+  });
+
+  test("round-trips arbitrary non-empty compose project names", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 40 }).filter((value) => !value.includes("\0")),
+        (composeProjectName) => {
+          const env = withEnv({ COMPOSE_PROJECT_NAME: composeProjectName }, () =>
+            loadDeploymentEnv({
+              envPath: "/nonexistent/.env",
+              requirePat: false
+            })
+          );
+
+          expect(env.composeProjectName).toBe(composeProjectName);
+          expect(env.raw.COMPOSE_PROJECT_NAME).toBe(composeProjectName);
+        }
+      ),
+      propertyOptions
+    );
+  });
+});
+
+function withEnv<T>(
+  overrides: Record<string, string | undefined>,
+  callback: () => T
+): T {
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(overrides)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function isSupportedBoolean(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return [
+    "1",
+    "true",
+    "yes",
+    "on",
+    "0",
+    "false",
+    "no",
+    "off"
+  ].includes(normalized);
+}
+
+function pathFromHome(segment: string): string {
+  return path.join(os.homedir(), segment);
+}


### PR DESCRIPTION
Closes #50

Implements the Daedalus-assigned fix for: Add property-based tests for config validation (fast-check)
