### PR TITLE
fix: address issue #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ That installer path:
 
 Use `pnpm drain-pool ...` before planned maintenance to remove idle runners from GitHub dispatch and wait for busy runners to finish. Teardown commands also accept `--drain --drain-timeout 15m` when you want that drain gate inline before `docker compose down`.
 
+Use `pnpm prune-stale-runners -- --format json --env .env` to report offline GitHub runner registrations that are no longer expected by the configured pool slots. The command is a dry run by default and only deregisters those offline, non-busy ghost runners when you pass `--apply`.
+
 Use `pnpm teardown-synology-project ...` when you want an explicit `docker compose down` on the NAS before reinstalling or when you want the runner project fully stopped.
 
 It intentionally avoids undocumented `SYNO.Docker.Project create/import` calls. If the Synology Docker daemon can see the compose project normally, Container Manager should still surface it as a compose project after the install task runs.
@@ -418,6 +420,7 @@ SMOKE_KEEP_ARTIFACTS=1 pnpm smoke-test
 - `pnpm render-linux-docker-project-manifest -- --config config/linux-docker-runners.yaml --env .env` for the remote Linux Docker install plan before you push it
 - `pnpm validate-config -- --config config/pools.yaml --env .env` for schema, resource, and policy mismatches
 - `pnpm validate-github -- --config config/pools.yaml --env .env` for missing runner groups or GitHub auth failures
+- `pnpm prune-stale-runners -- --format json --env .env` for dry-run stale offline runner cleanup across configured pool groups
 - `pnpm validate-image -- --config config/pools.yaml --env .env` for GHCR tag drift before deploy
 - `pnpm validate-lume-config -- --config config/lume-runners.yaml --env .env` for macOS pool config validation
 - `bash scripts/lume/status.sh --config config/lume-runners.yaml --env .env` for current host-side Lume slot state

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "mutation-test": "stryker run",
+    "prune-stale-runners": "tsx src/cli.ts prune-stale-runners",
     "validate-config": "tsx src/cli.ts validate-config",
     "validate-linux-docker-config": "tsx src/cli.ts validate-linux-docker-config",
     "validate-linux-docker-github": "tsx src/cli.ts validate-linux-docker-github",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,10 @@ import {
   type DrainProgress,
   type DrainReport
 } from "./lib/drain.js";
+import {
+  pruneStaleRunners,
+  type PruneStaleRunnersReport
+} from "./lib/prune.js";
 import { loadDeploymentEnv } from "./lib/env.js";
 import { loadLinuxDockerConfig } from "./lib/linux-docker-config.js";
 import {
@@ -91,6 +95,9 @@ export async function main(
       break;
     case "drain-pool":
       await drainPoolCommand(args);
+      break;
+    case "prune-stale-runners":
+      await pruneStaleRunnersCommand(args);
       break;
     case "validate-linux-docker-config":
       await validateLinuxDockerConfig(args);
@@ -264,6 +271,38 @@ async function driftDetectCommand(args: string[]): Promise<void> {
     );
     process.exitCode = 1;
   }
+}
+
+async function pruneStaleRunnersCommand(args: string[]): Promise<void> {
+  const env = loadDeploymentEnv({
+    envPath: getOption(args, "--env", ".env"),
+    requirePat: true
+  });
+  const format = getOption(args, "--format", "text")!;
+  if (format !== "text" && format !== "json") {
+    throw new Error(`unknown prune-stale-runners format: ${format}`);
+  }
+
+  const plane = getOption(args, "--plane") as DrainPlane | undefined;
+  if (
+    plane &&
+    !["synology", "linux-docker", "windows-docker", "lume"].includes(plane)
+  ) {
+    throw new Error(`unknown prune-stale-runners plane: ${plane}`);
+  }
+
+  const report = await pruneStaleRunners({
+    apiUrl: env.githubApiUrl,
+    token: env.githubPat!,
+    pools: collectDrainPoolDefinitions(args, env, plane),
+    apply: args.includes("--apply")
+  });
+
+  process.stdout.write(
+    format === "json"
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : renderPruneStaleRunnersReport(report)
+  );
 }
 
 async function auditLogCommand(args: string[]): Promise<void> {
@@ -1463,6 +1502,30 @@ function renderDrainReport(plane: DrainPlane, report: DrainReport): string {
   ].join("\n");
 }
 
+function renderPruneStaleRunnersReport(
+  report: PruneStaleRunnersReport
+): string {
+  const lines = [
+    `prune-stale-runners mode=${report.apply ? "apply" : "dry-run"}`,
+    `groups scanned: ${report.groups.length}`,
+    `stale runners: ${report.stale.length}`,
+    `deleted: ${report.deleted.length}`
+  ];
+
+  for (const runner of report.stale) {
+    lines.push(
+      `- ${runner.organization}/${runner.runnerGroup} ${runner.name} (${runner.plane}/${runner.poolKey}) id=${runner.id}` +
+        (report.apply ? ` deleted=${runner.deleted === true ? "yes" : "no"}` : "")
+    );
+  }
+
+  if (!report.apply && report.stale.length > 0) {
+    lines.push("rerun with --apply to deregister the stale offline runners");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
 function getDoctorMode(args: string[]): DoctorMode {
   const optionFlags = new Set([
     "--env",
@@ -1836,6 +1899,7 @@ function printUsage(): void {
   pnpm audit-log [--file /var/log/runner-fleet/audit.jsonl] [--max-size-bytes 10485760] < event.json
   pnpm drift-detect [--config config/pools.yaml] [--env .env] [--threshold 0]
   pnpm drain-pool -- --pool synology-private [--plane synology|linux-docker|windows-docker|lume] [--env .env] [--config config/pools.yaml] [--linux-config config/linux-docker-runners.yaml] [--windows-config config/windows-runners.yaml] [--lume-config config/lume-runners.yaml] [--timeout 15m] [--interval 5] [--format text|json]
+  pnpm prune-stale-runners [--plane synology|linux-docker|windows-docker|lume] [--env .env] [--config config/pools.yaml] [--linux-config config/linux-docker-runners.yaml] [--windows-config config/windows-runners.yaml] [--lume-config config/lume-runners.yaml] [--format text|json] [--apply]
   pnpm scale [--config config/pools.yaml] [--env .env] [--pool synology-private] [--dry-run] [--drain-timeout 300] [--drain-interval 5] [--python python3]
   pnpm validate-config [--config config/pools.yaml] [--env .env]
   pnpm validate-linux-docker-config [--config config/linux-docker-runners.yaml] [--env .env]

--- a/src/lib/prune.ts
+++ b/src/lib/prune.ts
@@ -1,0 +1,196 @@
+import {
+  deleteOrganizationRunner,
+  fetchOrganizationRunnerGroups,
+  fetchOrganizationRunners,
+  type FetchLike,
+  type GitHubRunner
+} from "./github.js";
+
+export interface PrunePoolDefinition {
+  plane: string;
+  key: string;
+  organization: string;
+  runnerGroup: string;
+  runnerNames: string[];
+}
+
+export interface StaleRunnerCandidate {
+  plane: string;
+  poolKey: string;
+  organization: string;
+  runnerGroup: string;
+  id: number;
+  name: string;
+  status: string;
+  busy: boolean;
+  deleted?: boolean;
+}
+
+export interface PruneStaleRunnersReport {
+  apply: boolean;
+  groups: Array<{
+    plane: string;
+    poolKey: string;
+    organization: string;
+    runnerGroup: string;
+    expected: string[];
+    scanned: number;
+  }>;
+  stale: StaleRunnerCandidate[];
+  deleted: string[];
+}
+
+export interface PruneStaleRunnersOptions {
+  apiUrl: string;
+  token: string;
+  pools: PrunePoolDefinition[];
+  apply: boolean;
+  fetchImpl?: FetchLike;
+}
+
+export async function pruneStaleRunners(
+  options: PruneStaleRunnersOptions
+): Promise<PruneStaleRunnersReport> {
+  const groups = mergeDefinitions(options.pools);
+  const stale: StaleRunnerCandidate[] = [];
+  const deleted: string[] = [];
+  const groupsByOrganization = groupByOrganization(groups);
+
+  for (const [organization, definitions] of groupsByOrganization.entries()) {
+    const [runnerGroups, runners] = await Promise.all([
+      fetchOrganizationRunnerGroups(
+        options.apiUrl,
+        organization,
+        options.token,
+        options.fetchImpl
+      ),
+      fetchOrganizationRunners(
+        options.apiUrl,
+        organization,
+        options.token,
+        options.fetchImpl
+      )
+    ]);
+
+    for (const definition of definitions) {
+      const runnerGroup = runnerGroups.find(
+        (group) => group.name === definition.runnerGroup
+      );
+      if (!runnerGroup) {
+        const available =
+          runnerGroups.map((group) => group.name).sort().join(", ") || "none";
+        throw new Error(
+          `pool ${definition.key} expects runner group ${definition.runnerGroup} in organization ${organization}, but GitHub returned: ${available}`
+        );
+      }
+
+      const expectedNames = new Set(definition.runnerNames);
+      const scopedRunners = runners.filter(
+        (runner) => runner.runnerGroupId === runnerGroup.id
+      );
+      const candidates: StaleRunnerCandidate[] = scopedRunners
+        .filter((runner) => isSafeStaleRunner(runner, expectedNames))
+        .map((runner) => ({
+          plane: definition.plane,
+          poolKey: definition.key,
+          organization,
+          runnerGroup: definition.runnerGroup,
+          id: runner.id,
+          name: runner.name,
+          status: runner.status,
+          busy: runner.busy ?? false
+        }));
+
+      for (const candidate of candidates) {
+        if (options.apply) {
+          candidate.deleted = await deleteOrganizationRunner(
+            options.apiUrl,
+            organization,
+            options.token,
+            candidate.id,
+            options.fetchImpl
+          );
+          if (candidate.deleted) {
+            deleted.push(candidate.name);
+          }
+        }
+        stale.push(candidate);
+      }
+
+      definition.scanned = scopedRunners.length;
+    }
+  }
+
+  return {
+    apply: options.apply,
+    groups: groups.map((group) => ({
+      plane: group.plane,
+      poolKey: group.key,
+      organization: group.organization,
+      runnerGroup: group.runnerGroup,
+      expected: [...group.runnerNames].sort(),
+      scanned: group.scanned ?? 0
+    })),
+    stale,
+    deleted: deleted.sort()
+  };
+}
+
+function isSafeStaleRunner(
+  runner: GitHubRunner,
+  expectedNames: Set<string>
+): boolean {
+  return (
+    runner.status === "offline" &&
+    runner.busy !== true &&
+    !expectedNames.has(runner.name)
+  );
+}
+
+type MergedPrunePoolDefinition = PrunePoolDefinition & { scanned?: number };
+
+function mergeDefinitions(
+  pools: PrunePoolDefinition[]
+): MergedPrunePoolDefinition[] {
+  const merged = new Map<string, MergedPrunePoolDefinition>();
+
+  for (const pool of pools) {
+    const key = [pool.organization, pool.runnerGroup].join("\0");
+    const existing = merged.get(key);
+    if (existing) {
+      existing.plane = uniqueSorted([...existing.plane.split(","), pool.plane]).join(",");
+      existing.key = uniqueSorted([...existing.key.split(","), pool.key]).join(",");
+      existing.runnerNames = uniqueSorted([
+        ...existing.runnerNames,
+        ...pool.runnerNames
+      ]);
+      continue;
+    }
+
+    merged.set(key, {
+      ...pool,
+      runnerNames: uniqueSorted(pool.runnerNames)
+    });
+  }
+
+  return [...merged.values()];
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function groupByOrganization(
+  pools: MergedPrunePoolDefinition[]
+): Map<string, MergedPrunePoolDefinition[]> {
+  const grouped = new Map<string, MergedPrunePoolDefinition[]>();
+
+  for (const pool of pools) {
+    grouped.set(pool.organization, [
+      ...(grouped.get(pool.organization) ?? []),
+      pool
+    ]);
+  }
+
+  return grouped;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1085,6 +1085,100 @@ describe("cli integration", () => {
     );
   });
 
+  test("prune-stale-runners defaults to dry-run JSON output", async () => {
+    const fixture = createCliFixture();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              runner_groups: [
+                {
+                  id: 7,
+                  name: "synology-private",
+                  visibility: "all",
+                  default: false
+                }
+              ]
+            })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              runners: [
+                {
+                  id: 301,
+                  name: "synology-private-runner-01",
+                  status: "offline",
+                  busy: false,
+                  runner_group_id: 7
+                },
+                {
+                  id: 302,
+                  name: "synology-private-runner-old",
+                  status: "offline",
+                  busy: false,
+                  runner_group_id: 7
+                },
+                {
+                  id: 303,
+                  name: "synology-private-runner-busy",
+                  status: "offline",
+                  busy: true,
+                  runner_group_id: 7
+                }
+              ]
+            })
+        })
+    );
+
+    const result = await invokeCli([
+      "prune-stale-runners",
+      "--env",
+      fixture.envPath,
+      "--plane",
+      "synology",
+      "--config",
+      fixture.synologyConfigPath,
+      "--format",
+      "json"
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(JSON.parse(result.stdout)).toEqual({
+      apply: false,
+      groups: [
+        {
+          plane: "synology",
+          poolKey: "synology-private",
+          organization: "example",
+          runnerGroup: "synology-private",
+          expected: ["synology-private-runner-01"],
+          scanned: 3
+        }
+      ],
+      stale: [
+        {
+          plane: "synology",
+          poolKey: "synology-private",
+          organization: "example",
+          runnerGroup: "synology-private",
+          id: 302,
+          name: "synology-private-runner-old",
+          status: "offline",
+          busy: false
+        }
+      ],
+      deleted: []
+    });
+  });
+
   test("drift detection writes an opt-in step summary notification", async () => {
     const fixture = createCliFixture();
     const stepSummaryPath = path.join(fixture.directory, "step-summary.md");

--- a/test/prune.test.ts
+++ b/test/prune.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test, vi } from "vitest";
+import { pruneStaleRunners } from "../src/lib/prune.js";
+
+describe("stale runner pruning", () => {
+  test("reports offline unexpected runners without deleting by default", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ runner_groups: runnerGroups() }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          runners: [
+            runner(101, "synology-private-runner-01", "online", false),
+            runner(102, "synology-private-runner-02", "offline", false),
+            runner(103, "synology-private-runner-old", "offline", false),
+            runner(104, "synology-private-runner-busy", "offline", true),
+            runner(105, "synology-private-runner-live", "online", false)
+          ]
+        })
+      );
+
+    const report = await pruneStaleRunners({
+      apiUrl: "https://api.github.test",
+      token: "token",
+      pools: [
+        {
+          plane: "synology",
+          key: "synology-private",
+          organization: "example",
+          runnerGroup: "synology-private",
+          runnerNames: [
+            "synology-private-runner-01",
+            "synology-private-runner-02"
+          ]
+        }
+      ],
+      apply: false,
+      fetchImpl
+    });
+
+    expect(report).toEqual({
+      apply: false,
+      groups: [
+        {
+          plane: "synology",
+          poolKey: "synology-private",
+          organization: "example",
+          runnerGroup: "synology-private",
+          expected: [
+            "synology-private-runner-01",
+            "synology-private-runner-02"
+          ],
+          scanned: 5
+        }
+      ],
+      stale: [
+        {
+          plane: "synology",
+          poolKey: "synology-private",
+          organization: "example",
+          runnerGroup: "synology-private",
+          id: 103,
+          name: "synology-private-runner-old",
+          status: "offline",
+          busy: false
+        }
+      ],
+      deleted: []
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test("deletes only safe stale runners when apply is enabled", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ runner_groups: runnerGroups() }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          runners: [
+            runner(201, "synology-private-runner-01", "offline", false),
+            runner(202, "synology-private-runner-old", "offline", false),
+            runner(203, "synology-private-runner-live", "online", false),
+            runner(204, "synology-private-runner-busy", "offline", true)
+          ]
+        })
+      )
+      .mockResolvedValueOnce({ ok: true, status: 204, text: async () => "" });
+
+    const report = await pruneStaleRunners({
+      apiUrl: "https://api.github.test",
+      token: "token",
+      pools: [
+        {
+          plane: "synology",
+          key: "synology-private",
+          organization: "example",
+          runnerGroup: "synology-private",
+          runnerNames: ["synology-private-runner-01"]
+        }
+      ],
+      apply: true,
+      fetchImpl
+    });
+
+    expect(report.stale).toEqual([
+      expect.objectContaining({
+        id: 202,
+        name: "synology-private-runner-old",
+        deleted: true
+      })
+    ]);
+    expect(report.deleted).toEqual(["synology-private-runner-old"]);
+    expect(fetchImpl).toHaveBeenLastCalledWith(
+      "https://api.github.test/orgs/example/actions/runners/202",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  test("unions expected names when multiple pools share a runner group", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ runner_groups: runnerGroups() }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          runners: [
+            runner(301, "pool-a-runner-01", "offline", false),
+            runner(302, "pool-b-runner-01", "offline", false),
+            runner(303, "old-runner", "offline", false)
+          ]
+        })
+      );
+
+    const report = await pruneStaleRunners({
+      apiUrl: "https://api.github.test",
+      token: "token",
+      pools: [
+        {
+          plane: "synology",
+          key: "pool-a",
+          organization: "example",
+          runnerGroup: "synology-private",
+          runnerNames: ["pool-a-runner-01"]
+        },
+        {
+          plane: "linux-docker",
+          key: "pool-b",
+          organization: "example",
+          runnerGroup: "synology-private",
+          runnerNames: ["pool-b-runner-01"]
+        }
+      ],
+      apply: false,
+      fetchImpl
+    });
+
+    expect(report.groups).toEqual([
+      expect.objectContaining({
+        plane: "linux-docker,synology",
+        poolKey: "pool-a,pool-b",
+        expected: ["pool-a-runner-01", "pool-b-runner-01"],
+        scanned: 3
+      })
+    ]);
+    expect(report.stale.map((runner) => runner.name)).toEqual(["old-runner"]);
+  });
+});
+
+function runnerGroups() {
+  return [{ id: 7, name: "synology-private", default: false }];
+}
+
+function runner(
+  id: number,
+  name: string,
+  status: "online" | "offline",
+  busy: boolean
+) {
+  return {
+    id,
+    name,
+    status,
+    busy,
+    runner_group_id: 7,
+    labels: [{ name: "self-hosted" }]
+  };
+}
+
+function jsonResponse(payload: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(payload)
+  };
+}

--- a/test/prune.test.ts
+++ b/test/prune.test.ts
@@ -162,6 +162,33 @@ describe("stale runner pruning", () => {
     ]);
     expect(report.stale.map((runner) => runner.name)).toEqual(["old-runner"]);
   });
+
+  test("reports none when GitHub returns no expected runner groups", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ runner_groups: [] }))
+      .mockResolvedValueOnce(jsonResponse({ runners: [] }));
+
+    await expect(
+      pruneStaleRunners({
+        apiUrl: "https://api.github.test",
+        token: "token",
+        pools: [
+          {
+            plane: "synology",
+            key: "synology-private",
+            organization: "example",
+            runnerGroup: "synology-private",
+            runnerNames: ["synology-private-runner-01"]
+          }
+        ],
+        apply: false,
+        fetchImpl
+      })
+    ).rejects.toThrow(
+      "pool synology-private expects runner group synology-private in organization example, but GitHub returned: none"
+    );
+  });
 });
 
 function runnerGroups() {


### PR DESCRIPTION
Closes #58

Implements the Daedalus-assigned fix for: Build a tiny Go helper binary for instance lifecycle checks
