### PR TITLE
fix: address issue #63

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -176,6 +176,8 @@ run_smoke_case() {
 
   grep -q "POST /orgs/test-org/actions/runners/registration-token" "${LOG_DIR}/mock-api.log"
   grep -q "POST /orgs/test-org/actions/runners/remove-token" "${LOG_DIR}/mock-api.log"
+  grep -q -- "--token registration-token" "${state_dir}/config-invocations.log"
+  grep -q -- "remove --token remove-token" "${state_dir}/config-invocations.log"
   grep -q -- "--runnergroup synology-private --ephemeral --disableupdate" "${state_dir}/config-invocations.log"
   grep -q "config path: /tmp/runner-state/runner-home" "${state_dir}/config-context.log"
   grep -q "run path: /tmp/runner-state/runner-home" "${state_dir}/run-context.log"

--- a/scripts/smoke/mock-api.mjs
+++ b/scripts/smoke/mock-api.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const logPath = process.env.MOCK_LOG_PATH ?? "/tmp/mock-api.log";
+const port = Number(process.env.MOCK_PORT ?? "8080");
 fs.mkdirSync(path.dirname(logPath), { recursive: true });
 
 const server = http.createServer((req, res) => {
@@ -28,10 +29,10 @@ const server = http.createServer((req, res) => {
   res.end(JSON.stringify({ error: "not found" }));
 });
 
-server.listen(8080, "0.0.0.0", () => {
+server.listen(port, "0.0.0.0", () => {
   fs.appendFileSync(
     logPath,
-    `${new Date().toISOString()} listening 0.0.0.0:8080\n`,
+    `${new Date().toISOString()} listening 0.0.0.0:${port}\n`,
     "utf8"
   );
 });

--- a/test/smoke-harness.test.ts
+++ b/test/smoke-harness.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+describe("runner registration smoke harness", () => {
+  test("exercises registration and cleanup token flow in both execution modes", () => {
+    const script = fs.readFileSync(
+      path.resolve("scripts/smoke-test.sh"),
+      "utf8"
+    );
+
+    expect(script).toContain("run_smoke_case runner");
+    expect(script).toContain("run_smoke_case root");
+    expect(script).toContain(
+      "POST /orgs/test-org/actions/runners/registration-token"
+    );
+    expect(script).toContain("POST /orgs/test-org/actions/runners/remove-token");
+    expect(script).toContain("--token registration-token");
+    expect(script).toContain("remove --token remove-token");
+    expect(script).toContain(
+      "--runnergroup synology-private --ephemeral --disableupdate"
+    );
+  });
+
+  test("uses stubbed runner scripts instead of a live GitHub runner bundle", () => {
+    const configStub = fs.readFileSync(
+      path.resolve("scripts/smoke/actions-runner/config.sh"),
+      "utf8"
+    );
+    const runStub = fs.readFileSync(
+      path.resolve("scripts/smoke/actions-runner/run.sh"),
+      "utf8"
+    );
+
+    expect(configStub).toContain("config-invocations.log");
+    expect(configStub).toContain("touch .runner .credentials .credentials_rsaparams");
+    expect(runStub).toContain("run.sh stub executed");
+    expect(runStub).toContain("job output");
+  });
+});

--- a/test/smoke-harness.test.ts
+++ b/test/smoke-harness.test.ts
@@ -1,9 +1,142 @@
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const tempRoot of tempRoots.splice(0)) {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
+function makeTempRoot() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "runner-smoke-"));
+  tempRoots.push(tempRoot);
+  return tempRoot;
+}
+
+async function waitForReady(logPath: string, port: number) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (
+      fs.existsSync(logPath) &&
+      fs.readFileSync(logPath, "utf8").includes(`listening 0.0.0.0:${port}`)
+    ) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error("mock API did not become ready");
+}
 
 describe("runner registration smoke harness", () => {
-  test("exercises registration and cleanup token flow in both execution modes", () => {
+  test("serves deterministic registration and cleanup tokens", async () => {
+    const tempRoot = makeTempRoot();
+    const logPath = path.join(tempRoot, "mock-api.log");
+    const port = 18080 + Number(process.env.VITEST_POOL_ID ?? "0");
+    const server = spawn("node", ["scripts/smoke/mock-api.mjs"], {
+      env: {
+        ...process.env,
+        MOCK_LOG_PATH: logPath,
+        MOCK_PORT: String(port),
+      },
+      stdio: "ignore",
+    });
+
+    try {
+      await waitForReady(logPath, port);
+
+      await expect(
+        fetch(
+          `http://127.0.0.1:${port}/orgs/test-org/actions/runners/registration-token`,
+          { method: "POST" }
+        ).then((response) => response.json())
+      ).resolves.toEqual({ token: "registration-token" });
+
+      await expect(
+        fetch(
+          `http://127.0.0.1:${port}/orgs/test-org/actions/runners/remove-token`,
+          { method: "POST" }
+        ).then((response) => response.json())
+      ).resolves.toEqual({ token: "remove-token" });
+
+      const log = fs.readFileSync(logPath, "utf8");
+      expect(log).toContain(
+        "POST /orgs/test-org/actions/runners/registration-token"
+      );
+      expect(log).toContain("POST /orgs/test-org/actions/runners/remove-token");
+    } finally {
+      server.kill();
+    }
+  });
+
+  test("records runner config and execution state without a live runner bundle", () => {
+    const tempRoot = makeTempRoot();
+    const runnerHome = path.join(tempRoot, "runner-home");
+    const workDir = path.join(tempRoot, "_work");
+    fs.mkdirSync(runnerHome, { recursive: true });
+    fs.mkdirSync(workDir, { recursive: true });
+
+    const env = {
+      ...process.env,
+      RUNNER_EXECUTION_MODE: "runner",
+      RUNNER_STATE_DIR: tempRoot,
+      RUNNER_WORK_DIR: workDir,
+    };
+
+    const configResult = spawnSync(
+      "bash",
+      [
+        path.resolve("scripts/smoke/actions-runner/config.sh"),
+        "--unattended",
+        "--token",
+        "registration-token",
+        "--runnergroup",
+        "synology-private",
+        "--ephemeral",
+        "--disableupdate",
+      ],
+      { cwd: runnerHome, encoding: "utf8", env }
+    );
+    expect(configResult.status).toBe(0);
+
+    const runResult = spawnSync(
+      "bash",
+      [path.resolve("scripts/smoke/actions-runner/run.sh")],
+      { cwd: runnerHome, encoding: "utf8", env }
+    );
+    expect(runResult.status).toBe(0);
+    expect(runResult.stdout.trim()).toBe("job output");
+
+    const removeResult = spawnSync(
+      "bash",
+      [
+        path.resolve("scripts/smoke/actions-runner/config.sh"),
+        "remove",
+        "--token",
+        "remove-token",
+      ],
+      { cwd: runnerHome, encoding: "utf8", env }
+    );
+    expect(removeResult.status).toBe(0);
+
+    expect(fs.readFileSync(path.join(tempRoot, "config-invocations.log"), "utf8"))
+      .toContain("--token registration-token");
+    expect(fs.readFileSync(path.join(tempRoot, "config-invocations.log"), "utf8"))
+      .toContain("remove --token remove-token");
+    expect(fs.readFileSync(path.join(tempRoot, "config-context.log"), "utf8"))
+      .toContain("config path: " + runnerHome);
+    expect(fs.readFileSync(path.join(tempRoot, "run-context.log"), "utf8"))
+      .toContain("run mode: runner");
+    expect(fs.existsSync(path.join(runnerHome, ".runner"))).toBe(true);
+    expect(fs.existsSync(path.join(workDir, "workspace", "job.txt"))).toBe(true);
+  });
+
+  test("wires the smoke script to run both execution modes and verify cleanup", () => {
     const script = fs.readFileSync(
       path.resolve("scripts/smoke-test.sh"),
       "utf8"
@@ -11,30 +144,11 @@ describe("runner registration smoke harness", () => {
 
     expect(script).toContain("run_smoke_case runner");
     expect(script).toContain("run_smoke_case root");
+    expect(script).toContain("grep -q -- \"remove --token remove-token\"");
     expect(script).toContain(
-      "POST /orgs/test-org/actions/runners/registration-token"
+      "grep -q \"runner registration removed cleanly\""
     );
-    expect(script).toContain("POST /orgs/test-org/actions/runners/remove-token");
-    expect(script).toContain("--token registration-token");
-    expect(script).toContain("remove --token remove-token");
-    expect(script).toContain(
-      "--runnergroup synology-private --ephemeral --disableupdate"
-    );
-  });
-
-  test("uses stubbed runner scripts instead of a live GitHub runner bundle", () => {
-    const configStub = fs.readFileSync(
-      path.resolve("scripts/smoke/actions-runner/config.sh"),
-      "utf8"
-    );
-    const runStub = fs.readFileSync(
-      path.resolve("scripts/smoke/actions-runner/run.sh"),
-      "utf8"
-    );
-
-    expect(configStub).toContain("config-invocations.log");
-    expect(configStub).toContain("touch .runner .credentials .credentials_rsaparams");
-    expect(runStub).toContain("run.sh stub executed");
-    expect(runStub).toContain("job output");
+    expect(script).toContain("verify_python_toolcache");
+    expect(script).toContain("verify_docker_cli");
   });
 });

--- a/test/smoke-harness.test.ts
+++ b/test/smoke-harness.test.ts
@@ -80,6 +80,7 @@ describe("runner registration smoke harness", () => {
     const workDir = path.join(tempRoot, "_work");
     fs.mkdirSync(runnerHome, { recursive: true });
     fs.mkdirSync(workDir, { recursive: true });
+    const resolvedRunnerHome = fs.realpathSync(runnerHome);
 
     const env = {
       ...process.env,
@@ -129,7 +130,9 @@ describe("runner registration smoke harness", () => {
     expect(fs.readFileSync(path.join(tempRoot, "config-invocations.log"), "utf8"))
       .toContain("remove --token remove-token");
     expect(fs.readFileSync(path.join(tempRoot, "config-context.log"), "utf8"))
-      .toContain("config path: " + runnerHome);
+      .toContain("config path: " + resolvedRunnerHome);
+    expect(fs.readFileSync(path.join(tempRoot, "run-context.log"), "utf8"))
+      .toContain("run path: " + resolvedRunnerHome);
     expect(fs.readFileSync(path.join(tempRoot, "run-context.log"), "utf8"))
       .toContain("run mode: runner");
     expect(fs.existsSync(path.join(runnerHome, ".runner"))).toBe(true);


### PR DESCRIPTION
Closes #63

Implements the Daedalus-assigned fix for: Add integration test harness for runner registration flow
