### PR TITLE
Automate release publishing on main

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,6 +1,9 @@
 name: Release Image
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       publish_project_release:
@@ -95,6 +98,16 @@ jobs:
             exit 1
           fi
 
+      - name: guard automatic publish version
+        if: ${{ github.event_name == 'push' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ steps.release_meta.outputs.release_tag }}" >/dev/null 2>&1; then
+            echo "release ${{ steps.release_meta.outputs.release_tag }} already exists; bump package.json and config/pools.yaml before publishing a new image" >&2
+            exit 1
+          fi
+
       - run: ./scripts/build-image.sh "${{ steps.release_meta.outputs.image_ref }}" --push
 
       - run: |
@@ -123,7 +136,7 @@ jobs:
           docker run --rm --platform linux/arm64 --entrypoint /bin/sh "${{ steps.release_meta.outputs.image_ref }}" -lc \
             'command -v pgrep && pgrep --version | head -n 1 && docker --version && node --version && python3 --version && terraform version | head -n 1'
 
-      - if: ${{ inputs.publish_project_release }}
+      - if: ${{ github.event_name == 'push' || inputs.publish_project_release }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -282,11 +282,12 @@ The release workflow:
 - confirms both `linux/amd64` and `linux/arm64` are present
 - retries `pnpm validate-image` until the GitHub Packages API sees the new tag
 - runs post-publish toolchain checks for both `linux/amd64` and `linux/arm64`
-- can create the matching GitHub release tag `v<version>` when dispatched from `main` with `publish_project_release=true`
+- automatically creates the matching GitHub release tag `v<version>` after successful publishes from `main`
+- can still be dispatched manually from `main`; set `publish_project_release=true` to create the matching GitHub Release during a manual run
 
 Only point [config/pools.yaml](config/pools.yaml) at a tag that this workflow has already published and verified.
 
-If you want the repository release and GHCR image tag to stay aligned, merge the version bump to `main` first and then run the release workflow from `main` with `publish_project_release=true`. That will create the repo tag and GitHub Release after the image publish/verify steps succeed.
+To keep the repository release and GHCR image tag aligned, merge the version bump to `main`. The release workflow first checks whether the matching repo release already exists; if it does, the automatic run fails before publishing an image so an existing GHCR version tag is not replaced. For a new version, the workflow publishes and verifies the image, then creates the matching repo tag and GitHub Release.
 
 ## Runtime Contract
 

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -30,6 +30,9 @@ describe("release workflow", () => {
     };
 
     expect(workflow.on).toHaveProperty("workflow_dispatch");
+    expect(workflow.on.push).toMatchObject({
+      branches: ["main"]
+    });
     expect(workflow.permissions).toMatchObject({
       contents: "write",
       packages: "write"
@@ -93,6 +96,22 @@ describe("release workflow", () => {
           step.run.includes("release-image may only publish from main")
       )
     ).toBe(true);
+    const automaticPublishGuardIndex = steps.findIndex(
+      (step) =>
+        step.name === "guard automatic publish version" &&
+        step.if === "${{ github.event_name == 'push' }}" &&
+        typeof step.run === "string" &&
+        step.run.includes("gh release view") &&
+        step.run.includes("bump package.json and config/pools.yaml")
+    );
+    const imagePublishIndex = steps.findIndex(
+      (step) =>
+        typeof step.run === "string" &&
+        step.run.includes("./scripts/build-image.sh") &&
+        step.run.includes("--push")
+    );
+    expect(automaticPublishGuardIndex).toBeGreaterThan(-1);
+    expect(imagePublishIndex).toBeGreaterThan(automaticPublishGuardIndex);
     expect(
       steps.filter(
         (step) =>
@@ -105,7 +124,8 @@ describe("release workflow", () => {
     expect(
       steps.some(
         (step) =>
-          step.if === "${{ inputs.publish_project_release }}" &&
+          step.if ===
+            "${{ github.event_name == 'push' || inputs.publish_project_release }}" &&
           typeof step.run === "string" &&
           step.run.includes("gh release create") &&
           step.run.includes("--generate-notes")


### PR DESCRIPTION
## Summary
- run the release image workflow automatically on pushes to main
- create the matching GitHub Release/tag after automatic image verification succeeds
- update README release publishing docs for the automatic path

## Validation
- actionlint .github/workflows/release-image.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-image.yml"); puts "release-image.yml parses"'
- git diff --check -- .github/workflows/release-image.yml README.md