### PR TITLE
test: raise vitest test timeout to 30s for slow CI runners

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],
+    testTimeout: 30000,
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "html"],


### PR DESCRIPTION
## Summary

- The `test_self_hosted_trusted` job runs `pnpm test:coverage`. `test/config.property.test.ts` runs 40 fast-check iterations per property, each doing real filesystem I/O (`mkdtempSync` + YAML write + `loadConfig`).
- Under v8 coverage instrumentation on the slower self-hosted Synology runner, `test/config.property.test.ts:29` exceeded vitest's default 5s per-test timeout (`Test timed out in 5000ms`). This is why plain `pnpm test` passes but `pnpm test:coverage` fails (observed on PR #104).
- Added `testTimeout: 30000` to `vitest.config.ts` — a conventional, low-blast-radius change that tolerates slow CI hardware while still catching genuinely hung tests. Coverage thresholds and `numRuns` are unchanged.

## Test plan

- [x] `pnpm lint` passes on Node 24.14.1
- [x] `pnpm test:coverage` passes on Node 24.14.1 (coverage stable at 75.36% branches)
- [x] `pnpm build` passes

https://claude.ai/code/session_01QxQ71Yrf2Cn6zVfM4LY7AR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxQ71Yrf2Cn6zVfM4LY7AR)_