### PR TITLE
Bump release to 0.1.10

### DIFF
--- a/config/pools.yaml
+++ b/config/pools.yaml
@@ -1,7 +1,7 @@
 version: 1
 image:
   repository: ghcr.io/omt-global/github-runner-fleet
-  tag: 0.1.9
+  tag: 0.1.10
 pools:
   - key: synology-private
     visibility: private

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-runner-fleet",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "license": "MIT",
   "description": "Self-hosted GitHub runner fleet for Synology shell-only pools, Linux Docker hosts, and ephemeral Lume macOS VMs.",


### PR DESCRIPTION
## Summary

- bump `package.json` from `0.1.9` to `0.1.10`
- bump `config/pools.yaml` GHCR image tag from `0.1.9` to `0.1.10`
- confirmed there are no open GitHub issues in `OMT-Global/github-runner-fleet`, so there were no issue-described features to implement in this pass

## Verification

- `gh issue list --repo OMT-Global/github-runner-fleet --state open --limit 100 --json number,title,body,labels,assignees,url,updatedAt` returned `[]`
- `pnpm install --frozen-lockfile` passed
- `pnpm exec vitest run test/release-contract.test.ts` passed
- `pnpm lint` passed
- `pnpm build` passed
- `pnpm test` passed outside the sandbox: 46 files / 251 tests

## Notes

- The root checkout had a local `.git/config` write blocker (`Operation not permitted`), so this PR was prepared from a fresh temporary clone at `/private/tmp/github-runner-fleet-release`.
