### PR TITLE
Normalize CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @jmcte
+# Managed CODEOWNERS for OMT-Global native repos.
+* @pheidon @jmcte


### PR DESCRIPTION
Sets CODEOWNERS to Pheidon and JMCTE only, matching the OMT-Global native repo ownership policy.