### PR TITLE
Pin resolvable release workflow actions

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -59,7 +59,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: sigstore/cosign-installer@v4
+      - uses: sigstore/cosign-installer@v4.1.2
 
       - id: release_meta
         run: |

--- a/.github/workflows/rg-release.yml
+++ b/.github/workflows/rg-release.yml
@@ -48,7 +48,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ inputs.image-ref }}
-      - uses: sigstore/cosign-installer@v4
+      - uses: sigstore/cosign-installer@v4.1.2
       - run: cosign sign --yes ${{ inputs.image-ref }}@${{ steps.build.outputs.digest }}
       - uses: actions/attest-build-provenance@v3
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,19 +10,21 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  security-events: write
 
 jobs:
   scorecard:
     name: openssf-scorecard
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v3
+      - uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -56,7 +56,9 @@ describe("release workflow", () => {
       true
     );
     expect(steps.some((step) => step.uses === "docker/login-action@v4")).toBe(true);
-    expect(steps.some((step) => step.uses === "sigstore/cosign-installer@v4")).toBe(true);
+    expect(
+      steps.some((step) => step.uses === "sigstore/cosign-installer@v4.1.2")
+    ).toBe(true);
     expect(steps.some((step) => step.uses === "anchore/sbom-action@v0")).toBe(true);
     expect(
       steps.some((step) => step.uses === "actions/attest-build-provenance@v3")

--- a/test/security-workflow.test.ts
+++ b/test/security-workflow.test.ts
@@ -36,11 +36,15 @@ describe("security and reusable workflows", () => {
     ) as { on: Record<string, unknown>; permissions: Record<string, string>; jobs: Record<string, Record<string, unknown>> };
 
     expect(workflow.on).not.toHaveProperty("pull_request");
-    expect(workflow.permissions).toMatchObject({
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(workflow.jobs.scorecard["runs-on"]).toBe("ubuntu-latest");
+    expect(workflow.jobs.scorecard.permissions).toMatchObject({
       "id-token": "write",
       "security-events": "write"
     });
-    expect(workflow.jobs.scorecard["runs-on"]).toBe("ubuntu-latest");
+    expect(String(JSON.stringify(workflow))).toContain(
+      "ossf/scorecard-action@v2.4.3"
+    );
     expect(String(JSON.stringify(workflow))).toContain("publish_results");
   });
 


### PR DESCRIPTION
## Summary

- pin release cosign setup to the existing `sigstore/cosign-installer@v4.1.2` tag
- pin Scorecard to the existing `ossf/scorecard-action@v2.4.3` tag
- update workflow contract tests so unresolved major aliases do not regress back into CI

## Verification

- `pnpm exec vitest run test/release-workflow.test.ts test/security-workflow.test.ts` passed
- `pnpm lint` passed
- `actionlint .github/workflows/release-image.yml .github/workflows/rg-release.yml .github/workflows/scorecard.yml` passed

## Issue Link

No issue is linked. This is a post-merge CI/release repair for the release workflows that failed after PR #123 merged and closed the governed issue batch.
