### PR TITLE
ci: finish runner fleet update

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -28,11 +28,7 @@ env:
 jobs:
   publish_and_verify:
     name: publish-and-verify
-    runs-on:
-      - self-hosted
-      - linux
-      - shell-only
-      - public
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       SYNOLOGY_RUNNER_BASE_DIR: /volume1/docker/github-runner-fleet

--- a/.github/workflows/rg-security.yml
+++ b/.github/workflows/rg-security.yml
@@ -20,11 +20,7 @@ permissions:
 jobs:
   security:
     name: rg-security
-    runs-on:
-      - self-hosted
-      - linux
-      - shell-only
-      - public
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,11 +14,7 @@ permissions:
 jobs:
   scorecard:
     name: openssf-scorecard
-    runs-on:
-      - self-hosted
-      - linux
-      - shell-only
-      - public
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,11 +21,7 @@ env:
 jobs:
   codeql:
     name: codeql
-    runs-on:
-      - self-hosted
-      - linux
-      - shell-only
-      - public
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -37,11 +33,7 @@ jobs:
   dependency_review:
     name: dependency-review
     if: github.event_name == 'pull_request'
-    runs-on:
-      - self-hosted
-      - linux
-      - shell-only
-      - public
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -52,11 +44,7 @@ jobs:
 
   osv:
     name: osv
-    runs-on:
-      - self-hosted
-      - linux
-      - shell-only
-      - public
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/scripts/lume/install-runtime.sh
+++ b/scripts/lume/install-runtime.sh
@@ -67,7 +67,7 @@ GITHUB_API_URL=https://api.github.com
 LUME_RUNNER_BASE_DIR='${lume_base_dir}'
 LUME_RUNNER_ENV_FILE='${lume_base_dir}/runner.env'
 COMPOSE_PROJECT_NAME=github-runner-fleet
-RUNNER_VERSION=2.333.0
+RUNNER_VERSION=2.334.0
 EOF
   install -m 0600 "${temp_path}" "${env_path}"
   rm -f "${temp_path}"

--- a/test/lume-scripts.test.ts
+++ b/test/lume-scripts.test.ts
@@ -46,6 +46,8 @@ describe("Lume pool scripts", () => {
     expect(installRuntime).toContain("Library/Application Support/github-runner-fleet/controller");
     expect(installRuntime).toContain("rsync -a --delete");
     expect(installRuntime).toContain("pnpm --dir");
+    expect(installRuntime).toContain("RUNNER_VERSION=2.334.0");
+    expect(installRuntime).not.toContain("RUNNER_VERSION=2.333.0");
     expect(installRuntime).toContain("install_lume_controller_runtime");
     expect(installRuntime).toContain('if [[ -f "${runtime_env}" ]]');
     expect(installRuntime.indexOf('if [[ -f "${runtime_env}" ]]')).toBeLessThan(

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -3,10 +3,8 @@ import path from "node:path";
 import YAML from "yaml";
 import { describe, expect, test } from "vitest";
 
-const shellSafePublicRunner = ["self-hosted", "linux", "shell-only", "public"];
-
 describe("release workflow", () => {
-  test("publishes on shell-safe self-hosted runners, verifies the pushed tag, and can create a repo release from main", () => {
+  test("publishes on GitHub-hosted runners, verifies the pushed tag, and can create a repo release from main", () => {
     const workflow = YAML.parse(
       fs.readFileSync(
         path.resolve(".github/workflows/release-image.yml"),
@@ -41,7 +39,7 @@ describe("release workflow", () => {
       "id-token": "write",
       attestations: "write"
     });
-    expect(job["runs-on"]).toEqual(shellSafePublicRunner);
+    expect(job["runs-on"]).toBe("ubuntu-latest");
     expect(job.env).toMatchObject({
       GITHUB_PAT: "${{ secrets.GITHUB_TOKEN }}",
       SYNOLOGY_RUNNER_BASE_DIR: "/volume1/docker/github-runner-fleet"

--- a/test/security-workflow.test.ts
+++ b/test/security-workflow.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from "vitest";
 const shellSafePublicRunner = ["self-hosted", "linux", "shell-only", "public"];
 
 describe("security and reusable workflows", () => {
-  test("keeps security scans on shell-safe self-hosted runners with Security tab upload", () => {
+  test("keeps security scans on GitHub-hosted runners with Security tab upload", () => {
     const workflow = YAML.parse(
       fs.readFileSync(path.resolve(".github/workflows/security.yml"), "utf8")
     ) as { permissions: Record<string, string>; jobs: Record<string, Record<string, unknown>> };
@@ -16,7 +16,7 @@ describe("security and reusable workflows", () => {
       "security-events": "write"
     });
     for (const job of Object.values(workflow.jobs)) {
-      expect(job["runs-on"]).toEqual(shellSafePublicRunner);
+      expect(job["runs-on"]).toBe("ubuntu-latest");
     }
     expect(String(JSON.stringify(workflow))).toContain("github/codeql-action/init");
     expect(String(JSON.stringify(workflow))).toContain("dependency-review-action");
@@ -43,7 +43,7 @@ describe("security and reusable workflows", () => {
       "id-token": "write",
       "security-events": "write"
     });
-    expect(workflow.jobs.scorecard["runs-on"]).toEqual(shellSafePublicRunner);
+    expect(workflow.jobs.scorecard["runs-on"]).toBe("ubuntu-latest");
     expect(String(JSON.stringify(workflow))).toContain(
       "ossf/scorecard-action@v2.4.3"
     );
@@ -51,7 +51,7 @@ describe("security and reusable workflows", () => {
   });
 
   test("exposes rg-ci, rg-security, and rg-release as workflow_call artifacts", () => {
-    for (const fileName of ["rg-ci.yml", "rg-security.yml", "rg-release.yml"]) {
+    for (const fileName of ["rg-ci.yml", "rg-release.yml"]) {
       const workflow = YAML.parse(
         fs.readFileSync(path.resolve(".github/workflows", fileName), "utf8")
       ) as { on: Record<string, unknown>; jobs: Record<string, Record<string, unknown>> };
@@ -60,6 +60,15 @@ describe("security and reusable workflows", () => {
       for (const job of Object.values(workflow.jobs)) {
         expect(job["runs-on"]).toEqual(shellSafePublicRunner);
       }
+    }
+
+    const rgSecurity = YAML.parse(
+      fs.readFileSync(path.resolve(".github/workflows/rg-security.yml"), "utf8")
+    ) as { on: Record<string, unknown>; jobs: Record<string, Record<string, unknown>> };
+
+    expect(rgSecurity.on).toHaveProperty("workflow_call");
+    for (const job of Object.values(rgSecurity.jobs)) {
+      expect(job["runs-on"]).toBe("ubuntu-latest");
     }
   });
 });


### PR DESCRIPTION
## Summary
- move release-image, Security, Scorecard, and reusable rg-security jobs to GitHub-hosted runners so Docker/CodeQL tooling is current and writable
- update the Lume controller runtime default runner executable to GitHub Actions runner 2.334.0
- add test coverage that prevents the Lume runtime default from regressing to 2.333.0 and updates workflow placement expectations

## Validation
- `corepack pnpm test`
- `corepack pnpm build`

## Context
PR #128 upgraded the bundled runner executable to 2.334.0 and was merged, but the main branch release/security runs still failed on stale self-hosted runner infrastructure: Docker client/API mismatch, Scorecard container pull failure, and CodeQL toolcache permission errors. This follow-up keeps the project's release and security path on current hosted runner plumbing while shell-safe lane checks can remain self-hosted.
