### PR TITLE
Fix extended validation Node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: ./actions/setup-shell-safe-node
         with:
-          node-version: "24"
+          node-version: 24.14.1
       - uses: pnpm/action-setup@v6
         with:
           version: 10.32.1
@@ -122,9 +122,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: ./actions/setup-shell-safe-node
         with:
-          node-version: "24"
+          node-version: 24.14.1
       - uses: pnpm/action-setup@v6
         with:
           version: 10.32.1

--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -86,6 +86,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: ./actions/setup-shell-safe-node
+        with:
+          node-version: 24.14.1
+
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
 
@@ -97,6 +101,10 @@ jobs:
     if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
     steps:
       - uses: actions/checkout@v6
+
+      - uses: ./actions/setup-shell-safe-node
+        with:
+          node-version: 24.14.1
 
       - name: Run extended validation
         run: bash scripts/ci/run-extended-validation.sh

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -6,6 +6,36 @@ import { describe, expect, test } from "vitest";
 const shellSafePublicRunner = ["self-hosted", "linux", "shell-only", "public"];
 
 describe("CI workflow", () => {
+  test("bootstraps shell-safe Node before extended validation script jobs", () => {
+    const workflow = YAML.parse(
+      fs.readFileSync(
+        path.resolve(".github/workflows/extended-validation.yml"),
+        "utf8"
+      )
+    ) as {
+      jobs: Record<string, Record<string, unknown>>;
+    };
+
+    for (const jobName of ["fast-checks", "extended-checks"]) {
+      const job = workflow.jobs[jobName];
+      const steps = job.steps as Array<Record<string, unknown>>;
+      const setupNodeIndex = steps.findIndex(
+        (step) => step.uses === "./actions/setup-shell-safe-node"
+      );
+      const scriptIndex = steps.findIndex(
+        (step) =>
+          typeof step.run === "string" &&
+          step.run.includes("scripts/ci/run-")
+      );
+
+      expect(setupNodeIndex).toBeGreaterThan(-1);
+      expect(setupNodeIndex).toBeLessThan(scriptIndex);
+      expect(steps[setupNodeIndex]?.with).toMatchObject({
+        "node-version": "24.14.1"
+      });
+    }
+  });
+
   test("runs mutation testing in extended validation and uploads the report", () => {
     const workflow = YAML.parse(
       fs.readFileSync(
@@ -104,9 +134,17 @@ describe("CI workflow", () => {
     const trustedJob = workflow.jobs.test_self_hosted_trusted;
     const steps = trustedJob.steps as Array<Record<string, unknown>>;
     const setupNodeStep = steps.find(
-      (step) => step.uses === "actions/setup-node@v6"
+      (step) => step.uses === "./actions/setup-shell-safe-node"
+    );
+    const setupNodeIndex = steps.findIndex(
+      (step) => step.uses === "./actions/setup-shell-safe-node"
     );
     const pnpmStep = steps.find((step) => step.uses === "pnpm/action-setup@v6");
+    const linuxDockerSteps = workflow.jobs.linux_docker_contract_trusted
+      .steps as Array<Record<string, unknown>>;
+    const linuxDockerSetupNodeStep = linuxDockerSteps.find(
+      (step) => step.uses === "./actions/setup-shell-safe-node"
+    );
     const forkSteps = workflow.jobs.test_public_fork_pr.steps as Array<
       Record<string, unknown>
     >;
@@ -119,14 +157,15 @@ describe("CI workflow", () => {
       version: "10.32.1"
     });
     expect(setupNodeStep?.with).toMatchObject({
-      "node-version": "24"
+      "node-version": "24.14.1"
+    });
+    expect(linuxDockerSetupNodeStep?.with).toMatchObject({
+      "node-version": "24.14.1"
     });
     expect(forkSetupNodeStep?.with).toMatchObject({
       "node-version": "24"
     });
-    expect(steps.indexOf(setupNodeStep ?? {})).toBeLessThan(
-      steps.indexOf(pnpmStep ?? {})
-    );
+    expect(setupNodeIndex).toBeLessThan(steps.indexOf(pnpmStep ?? {}));
   });
 
   test("verifies the broader shell-safe toolchain contract on self-hosted runners", () => {


### PR DESCRIPTION
## Summary

- Bootstrap shell-safe Node before Extended Validation's fast and extended script jobs.
- Use shell-safe Node setup for trusted self-hosted Linux CI jobs that previously called `actions/setup-node`.
- Add workflow coverage that ensures the setup step runs before the affected scripts/actions.

## Why

Scheduled Extended Validation on `main` was running `run-extended-validation.sh` under the self-hosted runner image's Node 18 runtime. Coverage then failed with `No such built-in module: node:inspector/promises` even though the package requires Node >=20.

The first live PR run also showed the trusted self-hosted Linux CI jobs failing in `actions/setup-node@v6` while extracting Node because `tar` could not restore archive ownership inside the runner work/temp path. Those jobs now use the repository's shell-safe Node setup action.

## Verification

- `pnpm exec vitest run test/workflow.test.ts` — passed
- `bash scripts/ci/run-fast-checks.sh` — passed

## Linked issues

- None
